### PR TITLE
fix(KTN-FUNC-014, KTN-TEST-008): améliore détection et messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ Suite officielle d'analyseurs Go pour moderniser le code avec les dernières fon
 - ✅ **KTN-VAR-014 amélioré** : Ignore les types externes (frameworks comme Terraform)
 - ✅ **KTN-VAR-007 amélioré** : Ignore `[]T{}` (faux positifs), vérifie seulement `make([]T, 0)` sans capacity
 - ✅ **KTN-FUNC-011 amélioré** : Ignore returns triviaux (nil, true, false, `[]T{}`)
+- ✅ **KTN-FUNC-014 amélioré** : Détecte méthodes passées comme arguments (`mux.HandleFunc("/", a.handler)`)
+- ✅ **KTN-TEST-008 amélioré** : Messages enrichis avec liste des fonctions concernées
 
 ## Structure
 

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func014_special/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func014_special/good.go
@@ -57,3 +57,42 @@ func GetHelper() string {
 	// Appel du helper via la variable
 	return helperFunc()
 }
+
+// Mux simule un ServeMux HTTP.
+type Mux struct{}
+
+// HandleFunc simule http.ServeMux.HandleFunc.
+func (m *Mux) HandleFunc(pattern string, handler func()) {
+	// Simulation d'enregistrement
+	_ = pattern
+	_ = handler
+}
+
+// App simule une application web avec des handlers.
+type App struct {
+	mux *Mux
+}
+
+// handleLiveness est un handler HTTP passé comme argument.
+func (a *App) handleLiveness() {
+	// Handler de liveness
+}
+
+// handleReadiness est un handler HTTP passé comme argument.
+func (a *App) handleReadiness() {
+	// Handler de readiness
+}
+
+// registerHandlers est passé comme fonction à un appel.
+func registerHandlers() {
+	// Enregistrement des handlers
+}
+
+// RegisterRoutes enregistre les routes en passant les handlers comme arguments.
+func (a *App) RegisterRoutes() {
+	// Les handlers sont passés comme arguments à HandleFunc
+	a.mux.HandleFunc("/live", a.handleLiveness)
+	a.mux.HandleFunc("/ready", a.handleReadiness)
+	// Fonction passée comme argument
+	a.mux.HandleFunc("/register", registerHandlers)
+}


### PR DESCRIPTION
## Summary
- **KTN-FUNC-014**: Détecte méthodes passées comme arguments (`mux.HandleFunc("/", a.handler)`)
- **KTN-TEST-008**: Messages enrichis avec liste des fonctions concernées

## Test plan
- [x] Tests unitaires passent
- [x] Lint propre (0 issues)
- [x] Handlers HTTP détectés correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)