### PR TITLE
fix(KTN-TEST-005): seuil table-driven réduit à 2 assertions

### DIFF
--- a/pkg/analyzer/ktn/ktntest/005.go
+++ b/pkg/analyzer/ktn/ktntest/005.go
@@ -14,9 +14,8 @@ import (
 
 const (
 	// MIN_TEST_CASES est le nombre minimum de cas de test pour table-driven
-	// Note: 3 assertions = pattern répétitif qui devrait utiliser table-driven
-	// 2 assertions = normal (ex: vérifier erreur + résultat)
-	MIN_TEST_CASES int = 3
+	// Note: 2 assertions = pattern répétitif qui devrait utiliser table-driven
+	MIN_TEST_CASES int = 2
 )
 
 // Analyzer005 checks that tests use table-driven test pattern

--- a/pkg/analyzer/ktn/ktntest/005_external_test.go
+++ b/pkg/analyzer/ktn/ktntest/005_external_test.go
@@ -8,7 +8,8 @@ import (
 )
 
 func TestTest005(t *testing.T) {
-	// 7 erreurs: tests sans table-driven pattern
+	// 8 erreurs: tests sans table-driven pattern (>= 2 assertions)
+	// - TestCalculatorTwoAssertions (2 assertions)
 	// - TestStringLengthMultipleCases
 	// - TestIsEmptyRepeatedAssertions
 	// - TestToUpperManyScenarios
@@ -16,5 +17,5 @@ func TestTest005(t *testing.T) {
 	// - TestCountWordsMultipleInputs
 	// - TestWithAssertManyScenarios (testify/assert)
 	// - TestWithRequireManyScenarios (testify/require)
-	testhelper.TestGoodBadWithFiles(t, ktntest.Analyzer005, "test005", "good_test.go", "bad_test.go", 7)
+	testhelper.TestGoodBadWithFiles(t, ktntest.Analyzer005, "test005", "good_test.go", "bad_test.go", 8)
 }

--- a/pkg/analyzer/ktn/ktntest/005_internal_test.go
+++ b/pkg/analyzer/ktn/ktntest/005_internal_test.go
@@ -473,13 +473,13 @@ func TestExample(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "2 assertions t.Error (ne devrait pas déclencher)",
+			name: "2 assertions t.Error (devrait déclencher avec MIN_TEST_CASES=2)",
 			code: `package test
 func TestExample(t *testing.T) {
 	t.Error("error 1")
 	t.Error("error 2")
 }`,
-			want: false,
+			want: true,
 		},
 		{
 			name: "3 assertions assert.Equal (devrait déclencher)",

--- a/pkg/analyzer/ktn/ktntest/testdata/src/test005/bad_test.go
+++ b/pkg/analyzer/ktn/ktntest/testdata/src/test005/bad_test.go
@@ -6,6 +6,19 @@ import (
 	"github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktntest/testdata/src/test005"
 )
 
+// TestCalculatorTwoAssertions teste avec 2 assertions sans table-driven (PAS BIEN)
+func TestCalculatorTwoAssertions(t *testing.T) {
+	result, err := test005.Calculator("+", 2, 3)
+	// Vérification pas d'erreur
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Vérification résultat - 2ème assertion déclenche la règle
+	if result != 5 {
+		t.Errorf("got %d, want 5", result)
+	}
+}
+
 // TestStringLengthMultipleCases teste plusieurs cas sans table-driven (PAS BIEN)
 func TestStringLengthMultipleCases(t *testing.T) {
 	// Test cas 1

--- a/pkg/analyzer/ktn/ktntest/testdata/src/test005/good_test.go
+++ b/pkg/analyzer/ktn/ktntest/testdata/src/test005/good_test.go
@@ -6,14 +6,10 @@ import (
 	"github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktntest/testdata/src/test005"
 )
 
-// TestCalculatorSingleCase teste un seul cas simple (BIEN - une seule assertion)
-func TestCalculatorSingleCase(t *testing.T) {
-	result, err := test005.Calculator("+", 2, 3)
-	// Vérification pas d'erreur
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
-	// Vérification résultat
+// TestCalculatorSingleAssertion teste un seul cas avec une seule assertion (BIEN)
+func TestCalculatorSingleAssertion(t *testing.T) {
+	result, _ := test005.Calculator("+", 2, 3)
+	// Vérification résultat uniquement
 	if result != 5 {
 		t.Errorf("got %d, want 5", result)
 	}


### PR DESCRIPTION
## Summary
- Réduit `MIN_TEST_CASES` de 3 à 2 pour la règle KTN-TEST-005
- Un test avec 2+ assertions doit maintenant utiliser le pattern table-driven
- Met à jour les testdata pour refléter le nouveau comportement

## Changements
- `005.go`: MIN_TEST_CASES = 2 (était 3)
- `bad_test.go`: Ajout de `TestCalculatorTwoAssertions` (2 assertions = mauvais)
- `good_test.go`: `TestCalculatorSingleAssertion` n'a plus qu'1 assertion
- `005_external_test.go`: 8 erreurs attendues (était 7)
- `005_internal_test.go`: Test mis à jour pour refléter le nouveau seuil

## Test plan
- [x] Tous les tests passent
- [x] TestTest005 vérifie 8 erreurs dans bad_test.go

🤖 Generated with [Claude Code](https://claude.com/claude-code)