### PR TITLE
fix: remove overly broad /tmp/ filter that blocked external projects

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -15,16 +15,16 @@ Rapport de couverture généré automatiquement.
 
 | Icon | Package | Coverage |
 |:----:|---------|----------|
-| 🟢 | **TOTAL (Global)** | **94.2%** |
+| 🟢 | **TOTAL (Global)** | **94.4%** |
 | 🔵 | `github.com/kodflow/ktn-linter/cmd/ktn-linter` | 100.0% |
-| 🟢 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 95.7% |
+| 🟢 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 97.7% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.5% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnconst` | 98.4% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnfunc` | 95.3% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` | 91.5% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` | 95.2% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnreturn` | 98.4% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` | 93.9% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` | 94.0% |
 | 🟡 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktntest` | 88.3% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnvar` | 91.8% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/testhelper` | 100.0% |
@@ -39,12 +39,13 @@ Rapport de couverture généré automatiquement.
 
 ## Détail des packages incomplets
 
-### 🟢 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 95.7%
+### 🟢 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 97.7%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
 | 🟢 `lint.go:runLint` | 92.9% |
-| 🔴 `lint.go:runAnalyzers` | 76.5% |
+| 🔴 `lint.go:selectSingleRule` | 57.1% |
+| 🟡 `lint.go:analyzePackage` | 90.9% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` - 98.5%
 
@@ -90,18 +91,14 @@ Rapport de couverture généré automatiquement.
 | 🟢 `009.go:checkMagicNumbers` | 92.3% |
 | 🟢 `011.go:runFunc011` | 95.0% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` - 91.5%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` - 95.2%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
-| 🟡 `001.go:runInterface001` | 90.9% |
-| 🟡 `001.go:collectDeclarations` | 90.0% |
-| 🟢 `001.go:collectCompileTimeChecks` | 92.9% |
-| 🟡 `001.go:extractInterfaceFromCheck` | 80.0% |
-| 🔴 `001.go:extractInterfaceNameFromExpr` | 75.0% |
-| 🔴 `001.go:checkNodeForInterfaceUsage` | 75.0% |
-| 🟡 `001.go:reportUnusedInterfaces` | 90.0% |
-| 🔴 `001.go:checkTypeSwitch` | 75.0% |
+| 🟡 `001.go:collectInterfaces` | 85.7% |
+| 🟡 `001.go:extractTypesFromNode` | 88.9% |
+| 🟡 `001.go:extractEmbeddedTypes` | 85.7% |
+| 🔴 `001.go:extractCompositeType` | 66.7% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnreturn` - 98.4%
 
@@ -109,7 +106,7 @@ Rapport de couverture généré automatiquement.
 |------------------|------------|
 | 🟢 `002.go:checkNilReturns` | 92.3% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` - 93.9%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` - 94.0%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
@@ -249,4 +246,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-13 23:43:20*
+*Généré le: 2025-12-14 11:15:17*

--- a/cmd/ktn-linter/cmd/lint.go
+++ b/cmd/ktn-linter/cmd/lint.go
@@ -473,10 +473,9 @@ func filterDiagnostics(diagnostics []diagWithFset) []diagWithFset {
 	// Itération sur les éléments
 	for _, d := range diagnostics {
 		pos := d.fset.Position(d.diag.Pos)
-		// Ignorer les fichiers du cache Go et les fichiers temporaires
+		// Ignorer uniquement les fichiers du cache Go (pas les projets utilisateur dans /tmp)
 		// Vérification de la condition
 		if strings.Contains(pos.Filename, "/.cache/go-build/") ||
-			strings.Contains(pos.Filename, "/tmp/") ||
 			strings.Contains(pos.Filename, "\\cache\\go-build\\") {
 			continue
 		}

--- a/cmd/ktn-linter/cmd/lint_internal_test.go
+++ b/cmd/ktn-linter/cmd/lint_internal_test.go
@@ -566,9 +566,9 @@ func Test_filterDiagnostics(t *testing.T) {
 		expectedMessage string
 	}{
 		{
-			name:            "filters cache and tmp files",
+			name:            "filters only cache files, not tmp",
 			files:           []string{"test.go", "/.cache/go-build/test.go", "/tmp/test.go"},
-			expectedCount:   1,
+			expectedCount:   2,
 			expectedMessage: "msg-0",
 		},
 	}

--- a/pkg/analyzer/ktn/ktnstruct/001.go
+++ b/pkg/analyzer/ktn/ktnstruct/001.go
@@ -795,6 +795,7 @@ func collectMethodsByStruct(file *ast.File, pass *analysis.Pass) map[string][]sh
 }
 
 // formatFieldList formate une liste de champs en string.
+// Gère correctement les champs avec plusieurs noms (ex: a, b int).
 //
 // Params:
 //   - fields: liste de champs
@@ -813,7 +814,16 @@ func formatFieldList(fields *ast.FieldList, _pass *analysis.Pass) string {
 	// Parcourir les champs
 	for _, field := range fields.List {
 		typeStr := types.ExprString(field.Type)
-		parts = append(parts, typeStr)
+		// Compter combien de noms partagent ce type
+		count := len(field.Names)
+		// Si pas de noms explicites (type anonyme), count = 1
+		if count == 0 {
+			count = 1
+		}
+		// Ajouter le type pour chaque nom
+		for range count {
+			parts = append(parts, typeStr)
+		}
 	}
 
 	// Retour de la string jointe

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/good.go
@@ -106,6 +106,6 @@ var _ ExternalInterface = (*RepositoryImpl)(nil)
 
 // init utilise les fonctions privées
 func init() {
-	// Appel de useUserService
-	_ = useUserService(UserService{})
+	// Appel de useUserService avec une implémentation concrète
+	useUserService(&userServiceImpl{users: map[int]string{}})
 }

--- a/pkg/formatter/formatter_impl.go
+++ b/pkg/formatter/formatter_impl.go
@@ -187,9 +187,8 @@ func (f *formatterImpl) groupByFile(fset *token.FileSet, diagnostics []analysis.
 		pos := fset.Position(diag.Pos)
 		filename := pos.Filename
 
-		// Ignorer les fichiers du cache Go et les fichiers temporaires
+		// Ignorer uniquement les fichiers du cache Go (pas les projets utilisateur dans /tmp)
 		if strings.Contains(filename, "/.cache/go-build/") ||
-			strings.Contains(filename, "/tmp/") ||
 			strings.Contains(filename, "\\cache\\go-build\\") {
 			continue
 		}
@@ -233,9 +232,8 @@ func (f *formatterImpl) filterAndSortDiagnostics(fset *token.FileSet, diagnostic
 	// Itération sur les éléments
 	for _, diag := range diagnostics {
 		pos := fset.Position(diag.Pos)
-		// Ignorer les fichiers du cache Go et les fichiers temporaires
+		// Ignorer uniquement les fichiers du cache Go (pas les projets utilisateur dans /tmp)
 		if strings.Contains(pos.Filename, "/.cache/go-build/") ||
-			strings.Contains(pos.Filename, "/tmp/") ||
 			strings.Contains(pos.Filename, "\\cache\\go-build\\") {
 			continue
 		}


### PR DESCRIPTION
## Summary
- Remove `/tmp/` filter from 3 locations that prevented analysis of external projects
- Keep only `/.cache/go-build/` filter for actual Go cache files
- Fix `formatFieldList` to handle multiple parameter names per field

## Test plan
- [x] All 94+ tests pass with 94.4% coverage
- [x] Verified linter works on projects in `/tmp/`
- [x] Verified KTN-STRUCT-001 correctly detects structs without interfaces
- [x] Verified structs with compile-time checks are not flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)