### PR TITLE
fix(struct001): use TypesInfo for proper type resolution in signatures

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -24,7 +24,7 @@ Rapport de couverture généré automatiquement.
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnfunc` | 95.3% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` | 95.2% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnreturn` | 98.4% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` | 94.0% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` | 93.8% |
 | 🟡 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktntest` | 88.3% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnvar` | 91.8% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/testhelper` | 100.0% |
@@ -106,7 +106,7 @@ Rapport de couverture généré automatiquement.
 |------------------|------------|
 | 🟢 `002.go:checkNilReturns` | 92.3% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` - 94.0%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnstruct` - 93.8%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
@@ -124,6 +124,7 @@ Rapport de couverture généré automatiquement.
 | 🟡 `001.go:interfaceCoversAllPublicMethods` | 90.0% |
 | 🟡 `001.go:signaturesMatch` | 83.3% |
 | 🟢 `001.go:collectInterfaces` | 94.4% |
+| 🟢 `001.go:formatFieldList` | 93.8% |
 | 🟢 `002.go:runStruct002` | 95.2% |
 | 🟢 `003.go:isValidGetterToReport` | 92.3% |
 | 🟢 `003.go:isSimpleGetter` | 93.3% |
@@ -246,4 +247,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-14 11:15:17*
+*Généré le: 2025-12-14 12:29:27*

--- a/pkg/analyzer/ktn/ktnstruct/001.go
+++ b/pkg/analyzer/ktn/ktnstruct/001.go
@@ -796,6 +796,7 @@ func collectMethodsByStruct(file *ast.File, pass *analysis.Pass) map[string][]sh
 
 // formatFieldList formate une liste de champs en string.
 // Gère correctement les champs avec plusieurs noms (ex: a, b int).
+// Utilise pass.TypesInfo pour obtenir le type complet (avec package path).
 //
 // Params:
 //   - fields: liste de champs
@@ -803,7 +804,7 @@ func collectMethodsByStruct(file *ast.File, pass *analysis.Pass) map[string][]sh
 //
 // Returns:
 //   - string: représentation string
-func formatFieldList(fields *ast.FieldList, _pass *analysis.Pass) string {
+func formatFieldList(fields *ast.FieldList, pass *analysis.Pass) string {
 	// Si pas de champs
 	if fields == nil {
 		// Retour vide
@@ -813,7 +814,17 @@ func formatFieldList(fields *ast.FieldList, _pass *analysis.Pass) string {
 	var parts []string
 	// Parcourir les champs
 	for _, field := range fields.List {
-		typeStr := types.ExprString(field.Type)
+		// Utiliser TypesInfo pour obtenir le type résolu (avec chemin complet)
+		var typeStr string
+		if pass != nil && pass.TypesInfo != nil {
+			if t := pass.TypesInfo.TypeOf(field.Type); t != nil {
+				typeStr = types.TypeString(t, nil)
+			} else {
+				typeStr = types.ExprString(field.Type)
+			}
+		} else {
+			typeStr = types.ExprString(field.Type)
+		}
 		// Compter combien de noms partagent ce type
 		count := len(field.Names)
 		// Si pas de noms explicites (type anonyme), count = 1


### PR DESCRIPTION
## Summary
- Fix signature comparison for cross-package interface implementations
- Use `pass.TypesInfo.TypeOf()` to resolve types before stringifying
- Ensures both interface and struct methods use the same full path representation

## Problem
The linter was reporting false positives for structs that implement cross-package interfaces when:
- Interface is in `internal/domain/`
- Implementation is in `internal/infrastructure/`
- Compile-time check exists: `var _ domain.Interface = (*Impl)(nil)`

The issue was that `formatFieldList` used `types.ExprString` (returns `domain.Model`) while `formatTypeTuple` used `types.TypeString` (returns full path like `github.com/x/internal/domain.Model`).

## Test plan
- [x] All tests pass with 94.4% coverage
- [x] Verified fix with `KTN-STRUCT-001-internal-path.zip` test case
- [x] Previous repro case still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)