### PR TITLE
fix(struct001): improve error message with cross-package solution

### DIFF
--- a/pkg/analyzer/ktn/ktnstruct/001.go
+++ b/pkg/analyzer/ktn/ktnstruct/001.go
@@ -133,9 +133,10 @@ func checkStructs(pass *analysis.Pass, structs []structWithMethods, localInterfa
 		// Aucune interface ne couvre toutes les méthodes
 		pass.Reportf(
 			s.node.Pos(),
-			"KTN-STRUCT-001: la struct '%s' a %d méthode(s) publique(s) mais aucune interface ne les reprend toutes. Créer une interface complète dans le même fichier",
+			"KTN-STRUCT-001: la struct '%s' a %d méthode(s) publique(s) mais aucune interface ne les reprend toutes. Solutions: (1) créer une interface locale, ou (2) ajouter 'var _ Interface = (*%s)(nil)' pour une interface cross-package",
 			s.name,
 			len(s.methods),
+			s.name,
 		)
 	}
 }


### PR DESCRIPTION
## Summary
- Améliore le message d'erreur KTN-STRUCT-001 pour mentionner l'option compile-time check
- Guide les utilisateurs d'architecture hexagonale/clean avec interfaces cross-package

**Avant:**
```
la struct 'X' a N méthode(s) publique(s) mais aucune interface ne les reprend toutes. 
Créer une interface complète dans le même fichier
```

**Après:**
```
la struct 'X' a N méthode(s) publique(s) mais aucune interface ne les reprend toutes. 
Solutions: (1) créer une interface locale, ou (2) ajouter 'var _ Interface = (*X)(nil)' 
pour une interface cross-package
```

## Test plan
- [x] Tests passent
- [x] Message vérifié manuellement

🤖 Generated with [Claude Code](https://claude.com/claude-code)