### PR TITLE
feat(formatter): add verbose mode support for detailed messages

### DIFF
--- a/cmd/ktn-linter/cmd/lint.go
+++ b/cmd/ktn-linter/cmd/lint.go
@@ -445,7 +445,7 @@ func createAnalysisPass(a *analysis.Analyzer, pkg *packages.Package, fset *token
 //
 // Params:
 func formatAndDisplay(diagnostics []diagWithFset) {
-	fmtr := formatter.NewFormatter(os.Stdout, AIMode, NoColor, Simple)
+	fmtr := formatter.NewFormatter(os.Stdout, AIMode, NoColor, Simple, Verbose)
 
 	// Vérification de la condition
 	if len(diagnostics) == 0 {

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -77,6 +77,19 @@ func extractCode(message string) string {
 // Returns:
 //   - string: message nettoyé sans le code KTN
 func extractMessage(message string) string {
+	// Extraction avec troncature (mode normal)
+	return extractMessageWithOptions(message, true)
+}
+
+// extractMessageWithOptions extrait le message avec options.
+//
+// Params:
+//   - message: message brut du diagnostic
+//   - truncate: true pour tronquer au premier \n
+//
+// Returns:
+//   - string: message nettoyé sans le code KTN
+func extractMessageWithOptions(message string, truncate bool) string {
 	var idx int
 	// Supprimer le code [KTN-XXX-XXX] ou KTN-XXX-XXX:
 	// Traitement Format 1: [KTN-XXX-XXX] ...
@@ -93,9 +106,12 @@ func extractMessage(message string) string {
 		}
 	}
 
-	// Tronquer au premier \n pour avoir juste la première ligne
-	if idx = strings.Index(message, "\n"); idx != -1 {
-		message = message[:idx]
+	// Tronquer au premier \n si demandé (mode normal)
+	if truncate {
+		// Chercher le premier \n
+		if idx = strings.Index(message, "\n"); idx != -1 {
+			message = message[:idx]
+		}
 	}
 
 	// Retour du message nettoyé

--- a/pkg/formatter/formatter_impl_external_test.go
+++ b/pkg/formatter/formatter_impl_external_test.go
@@ -27,7 +27,7 @@ func TestNewFormatter(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			f := formatter.NewFormatter(buf, tt.aiMode, tt.noColor, tt.simpleMode)
+			f := formatter.NewFormatter(buf, tt.aiMode, tt.noColor, tt.simpleMode, false)
 			if f == nil {
 				t.Error("NewFormatter returned nil")
 			}
@@ -52,7 +52,7 @@ func TestFormatterImpl_Format(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
-			f := formatter.NewFormatter(&buf, false, true, false)
+			f := formatter.NewFormatter(&buf, false, true, false, false)
 			fset := token.NewFileSet()
 
 			// Execute format

--- a/pkg/formatter/formatter_impl_internal_test.go
+++ b/pkg/formatter/formatter_impl_internal_test.go
@@ -52,7 +52,7 @@ func TestFormatEmpty(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, tt.aiMode, tt.noColor, tt.simpleMode)
+			formatter := NewFormatter(buf, tt.aiMode, tt.noColor, tt.simpleMode, false)
 			fset := token.NewFileSet()
 
 			formatter.Format(fset, []analysis.Diagnostic{})
@@ -77,7 +77,7 @@ func TestFormatHumanMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, false, false, false)
+			formatter := NewFormatter(buf, false, false, false, false)
 			fset := token.NewFileSet()
 
 			fset.AddFile("test.go", 1, 1000)
@@ -107,7 +107,7 @@ func TestFormatAIMode(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, true, false, false)
+			formatter := NewFormatter(buf, true, false, false, false)
 			fset := token.NewFileSet()
 
 			fset.AddFile("test.go", 1, 1000)
@@ -164,7 +164,7 @@ func TestFormatSimpleMode(t *testing.T) {
 
 	// Préparation commune
 	buf := &bytes.Buffer{}
-	formatter := NewFormatter(buf, false, false, true)
+	formatter := NewFormatter(buf, false, false, true, false)
 	fset := token.NewFileSet()
 	fset.AddFile("test.go", 1, 1000)
 	diagnostics := createTestDiagnostics()
@@ -194,7 +194,7 @@ func TestFormatNoColor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, false, true, false)
+			formatter := NewFormatter(buf, false, true, false, false)
 			fset := token.NewFileSet()
 
 			fset.AddFile("test.go", 1, 1000)
@@ -703,7 +703,7 @@ func TestFormatSimpleModeWithFiltering(t *testing.T) {
 
 	// Préparation commune
 	buf := &bytes.Buffer{}
-	formatter := NewFormatter(buf, false, false, true)
+	formatter := NewFormatter(buf, false, false, true, false)
 	fset := token.NewFileSet()
 	file1 := fset.AddFile("normal.go", 1, 1000)
 	file1.AddLine(10)
@@ -776,7 +776,7 @@ func TestFormatterImpl_formatForHuman(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, false, false, false).(*formatterImpl)
+			formatter := NewFormatter(buf, false, false, false, false).(*formatterImpl)
 			fset := token.NewFileSet()
 			fset.AddFile("test.go", 1, 100)
 
@@ -808,7 +808,7 @@ func TestFormatterImpl_formatForAI(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, true, false, false).(*formatterImpl)
+			formatter := NewFormatter(buf, true, false, false, false).(*formatterImpl)
 			fset := token.NewFileSet()
 			fset.AddFile(tt.filename, 1, 100)
 
@@ -840,7 +840,7 @@ func TestFormatterImpl_formatSimple(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
-			formatter := NewFormatter(buf, false, false, true).(*formatterImpl)
+			formatter := NewFormatter(buf, false, false, true, false).(*formatterImpl)
 			fset := token.NewFileSet()
 			fset.AddFile(tt.filename, 1, 100)
 

--- a/pkg/messages/comment.go
+++ b/pkg/messages/comment.go
@@ -1,0 +1,151 @@
+// Comment messages for KTN-COMMENT rules.
+package messages
+
+// registerCommentMessages enregistre les messages COMMENT.
+func registerCommentMessages() {
+	Register(Message{
+		Code:  "KTN-COMMENT-001",
+		Short: "commentaire trop long (%d > 80 chars)",
+		Verbose: `PROBLÈME: Le commentaire fait %d caractères (max 80).
+
+POURQUOI: Les commentaires longs réduisent la lisibilité et cassent
+le formatage dans les terminaux et éditeurs standards.
+
+SOLUTIONS:
+  1. Raccourcir le commentaire
+  2. Passer en multi-ligne avec /* ... */
+  3. Déplacer au-dessus de la ligne concernée
+
+EXEMPLE INCORRECT:
+  x := getValue() // Ce commentaire est beaucoup trop long
+
+EXEMPLE CORRECT:
+  // Récupère la valeur depuis le cache
+  x := getValue()`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-002",
+		Short: "fichier sans commentaire descriptif avant 'package %s'",
+		Verbose: `PROBLÈME: Le fichier n'a pas de commentaire avant package %s.
+
+POURQUOI: Le commentaire de fichier documente le rôle du fichier.
+Il apparaît dans godoc et aide à la navigation.
+
+FORMAT ATTENDU:
+  // Description courte du fichier.
+  // Détails supplémentaires si nécessaire.
+  package monpackage
+
+EXEMPLE:
+  // repository.go implémente l'accès à la base de données.
+  // Il fournit les méthodes CRUD pour les entités User.
+  package database`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-003",
+		Short: "constante '%s' sans commentaire",
+		Verbose: `PROBLÈME: La constante '%s' n'a pas de commentaire explicatif.
+
+POURQUOI: Les constantes définissent des valeurs métier importantes.
+Sans documentation, leur signification se perd avec le temps.
+
+FORMAT ATTENDU:
+  // NomConstante définit/représente/indique...
+  const NomConstante = valeur
+
+EXEMPLE:
+  // MaxRetries définit le nombre max de tentatives de connexion
+  const MaxRetries = 3`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-004",
+		Short: "variable '%s' sans commentaire",
+		Verbose: `PROBLÈME: La variable de package '%s' n'a pas de commentaire.
+
+POURQUOI: Les variables de package ont une portée globale.
+Leur documentation évite les mauvais usages.
+
+FORMAT ATTENDU:
+  // nomVariable stocke/contient/gère...
+  var nomVariable Type = valeur
+
+EXEMPLE:
+  // defaultTimeout définit le délai d'attente par défaut.
+  var defaultTimeout = 30 * time.Second`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-005",
+		Short: "struct '%s' sans documentation complète (≥2 lignes requises)",
+		Verbose: `PROBLÈME: La struct exportée '%s' n'a pas de doc suffisante.
+
+POURQUOI: Les structs exportées font partie de l'API publique.
+Une documentation minimale (≥2 lignes) aide les utilisateurs.
+
+FORMAT ATTENDU:
+  // NomStruct représente/gère/contient...
+  // Description détaillée du rôle et de l'utilisation.
+  type NomStruct struct { ... }
+
+EXEMPLE:
+  // User représente un utilisateur du système.
+  // Il contient les informations d'identification et de profil.
+  type User struct { ... }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-006",
+		Short: "section '%s' manquante dans la doc de '%s'",
+		Verbose: `PROBLÈME: La fonction '%s' n'a pas la section '%s'.
+
+POURQUOI: Une documentation structurée permet de comprendre
+les entrées/sorties sans lire le code.
+
+FORMAT ATTENDU:
+  // NomFonction description courte.
+  //
+  // Params:
+  //   - param1: description
+  //
+  // Returns:
+  //   - Type: description
+  func NomFonction(param1 Type) Type
+
+EXEMPLE:
+  // GetUserByID récupère un utilisateur par ID.
+  //
+  // Params:
+  //   - id: identifiant unique
+  //
+  // Returns:
+  //   - *User: utilisateur trouvé
+  //   - error: ErrNotFound si inexistant
+  func GetUserByID(id int) (*User, error)`,
+	})
+
+	Register(Message{
+		Code:  "KTN-COMMENT-007",
+		Short: "bloc '%s' sans commentaire explicatif",
+		Verbose: `PROBLÈME: Le bloc '%s' n'a pas de commentaire.
+
+POURQUOI: Les blocs de contrôle contiennent la logique métier.
+Un commentaire aide à comprendre l'intention.
+
+BLOCS CONCERNÉS: if, else, switch, case, for, return
+
+EXEMPLE INCORRECT:
+  if user.Age < 18 {
+      return ErrUnderAge
+  }
+
+EXEMPLE CORRECT:
+  // Vérifier que l'utilisateur est majeur
+  if user.Age < 18 {
+      // Mineur - accès refusé
+      return ErrUnderAge
+  }`,
+	})
+}

--- a/pkg/messages/const.go
+++ b/pkg/messages/const.go
@@ -1,0 +1,75 @@
+// Const messages for KTN-CONST rules.
+package messages
+
+// registerConstMessages enregistre les messages CONST.
+func registerConstMessages() {
+	Register(Message{
+		Code:  "KTN-CONST-001",
+		Short: "constante '%s' sans type explicite",
+		Verbose: `PROBLÈME: La constante '%s' n'a pas de type déclaré.
+
+POURQUOI: Le typage explicite:
+  - Documente l'intention
+  - Évite les conversions implicites
+  - Améliore la lisibilité
+
+EXEMPLE INCORRECT:
+  const MaxSize = 1024
+  const Prefix = "app_"
+
+EXEMPLE CORRECT:
+  const MaxSize int = 1024
+  const Prefix string = "app_"
+
+EXCEPTION: Les constantes iota peuvent omettre le type.`,
+	})
+
+	Register(Message{
+		Code:  "KTN-CONST-002",
+		Short: "constantes mal organisées. Ordre: const → var → type → func",
+		Verbose: `PROBLÈME: Les constantes ne sont pas groupées ou mal placées.
+
+POURQUOI: L'ordre standardisé facilite la navigation:
+  1. const (constantes)
+  2. var (variables de package)
+  3. type (types et structs)
+  4. func (fonctions)
+
+EXEMPLE INCORRECT:
+  func DoSomething() {}
+  const MaxSize = 1024  // Après une fonction!
+
+EXEMPLE CORRECT:
+  const (
+      MaxSize  int    = 1024
+      MinSize  int    = 64
+  )
+
+  var defaultConfig = Config{}
+
+  type Config struct { ... }
+
+  func DoSomething() {}`,
+	})
+
+	Register(Message{
+		Code:  "KTN-CONST-003",
+		Short: "constante '%s' mal nommée. CamelCase requis, pas SCREAMING_SNAKE",
+		Verbose: `PROBLÈME: La constante '%s' utilise SCREAMING_SNAKE_CASE.
+
+POURQUOI: Go utilise CamelCase pour TOUT, y compris constantes.
+SCREAMING_SNAKE_CASE est une convention C/Java, pas Go.
+
+EXEMPLE INCORRECT:
+  const MAX_BUFFER_SIZE = 1024
+  const DEFAULT_TIMEOUT = 30
+
+EXEMPLE CORRECT:
+  const MaxBufferSize = 1024
+  const DefaultTimeout = 30
+
+NOTE: Constantes privées = camelCase (minuscule initiale).
+  const maxBufferSize = 1024  // Privée
+  const MaxBufferSize = 1024  // Exportée`,
+	})
+}

--- a/pkg/messages/func.go
+++ b/pkg/messages/func.go
@@ -1,0 +1,251 @@
+// Func messages for KTN-FUNC rules.
+package messages
+
+// registerFuncMessages enregistre les messages FUNC.
+func registerFuncMessages() {
+	Register(Message{
+		Code:  "KTN-FUNC-001",
+		Short: "error doit être le dernier retour, pas en position %d",
+		Verbose: `PROBLÈME: Le type 'error' est en position %d au lieu de dernier.
+
+POURQUOI: Convention Go universelle - error toujours en dernier:
+  - Cohérence avec la stdlib
+  - Pattern if err != nil { } naturel
+  - Facilite la lecture
+
+EXEMPLE INCORRECT:
+  func Process() (error, *Result) { ... }
+
+EXEMPLE CORRECT:
+  func Process() (*Result, error) { ... }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-002",
+		Short: "context.Context doit être le 1er paramètre, pas position %d",
+		Verbose: `PROBLÈME: context.Context est en position %d au lieu de 1er.
+
+POURQUOI: Convention Go standard (context package doc):
+  "Context should be the first parameter, named ctx"
+
+EXEMPLE INCORRECT:
+  func GetUser(id int, ctx context.Context) (*User, error)
+
+EXEMPLE CORRECT:
+  func GetUser(ctx context.Context, id int) (*User, error)
+
+NOTE: Pour méthodes, ctx vient après le receiver.`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-003",
+		Short: "else inutile après return/break/continue. Early return préféré",
+		Verbose: `PROBLÈME: Un bloc else suit un return/break/continue.
+
+POURQUOI: L'early return réduit l'indentation et améliore la lisibilité.
+
+EXEMPLE INCORRECT:
+  if err != nil {
+      return err
+  } else {
+      processData()
+      return nil
+  }
+
+EXEMPLE CORRECT:
+  if err != nil {
+      return err
+  }
+  processData()
+  return nil`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-004",
+		Short: "fonction privée '%s' jamais appelée (code mort)",
+		Verbose: `PROBLÈME: La fonction privée '%s' n'est appelée nulle part.
+
+POURQUOI: Le code mort:
+  - Alourdit la maintenance
+  - Induit en erreur
+  - Peut contenir des bugs cachés
+
+ACTIONS:
+  1. Utilisée dans tests → vérifier si vraiment utile
+  2. "Pour plus tard" → Supprimer, git la garde
+  3. Oubliée après refactoring → Supprimer`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-005",
+		Short: "fonction '%s' trop longue (%d lignes > 35). Extraire en sous-fonctions",
+		Verbose: `PROBLÈME: La fonction '%s' fait %d lignes (max 35).
+
+POURQUOI: Les fonctions courtes:
+  - Sont plus faciles à tester
+  - Ont un nom qui documente leur rôle
+  - Sont réutilisables
+
+CALCUL: Seul le code compté (hors commentaires/blancs).
+
+SOLUTION: Extraire en sous-fonctions nommées.
+
+EXEMPLE:
+  // Avant: 50 lignes
+  func ProcessOrder(order Order) error { ... }
+
+  // Après: fonctions courtes
+  func ProcessOrder(order Order) error {
+      if err := validateOrder(order); err != nil {
+          return err
+      }
+      return saveOrder(order)
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-006",
+		Short: "fonction '%s' a %d paramètres (max 5). Grouper dans struct",
+		Verbose: `PROBLÈME: La fonction '%s' a %d paramètres (max 5).
+
+POURQUOI: Trop de paramètres:
+  - Rendent l'appel difficile à lire
+  - Augmentent le risque d'inversion
+  - Signalent un problème de conception
+
+SOLUTION: Grouper dans une struct Options/Config.
+
+EXEMPLE INCORRECT:
+  func CreateUser(name, email, phone, address, city string) error
+
+EXEMPLE CORRECT:
+  type CreateUserRequest struct {
+      Name, Email, Phone, Address, City string
+  }
+  func CreateUser(req CreateUserRequest) error`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-007",
+		Short: "getter '%s' a des side effects. Un getter doit être pur",
+		Verbose: `PROBLÈME: Le getter '%s' (Get*/Is*/Has*) modifie l'état.
+
+POURQUOI: Un getter doit être "pur":
+  - Retourner sans modifier l'état
+  - Appelable plusieurs fois sans conséquence
+  - Pas d'effets observables
+
+EXEMPLE INCORRECT:
+  func (c *Counter) GetCount() int {
+      c.accessCount++  // Side effect!
+      return c.count
+  }
+
+EXEMPLE CORRECT:
+  func (c *Counter) GetCount() int {
+      return c.count
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-008",
+		Short: "paramètre '%s' non utilisé. Préfixer _ ou supprimer",
+		Verbose: `PROBLÈME: Le paramètre '%s' n'est pas utilisé.
+
+SOLUTIONS:
+  1. Supprimer si pas requis
+  2. Préfixer _ si imposé par interface: _param
+  3. Si "_ = param" → c'est du contournement, nettoyer
+
+EXEMPLE INCORRECT:
+  func Process(ctx context.Context, data []byte) error {
+      // ctx jamais utilisé
+      return nil
+  }
+
+EXEMPLE CORRECT (si interface l'impose):
+  func Process(_ctx context.Context, data []byte) error`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-009",
+		Short: "nombre magique %v. Extraire en constante nommée",
+		Verbose: `PROBLÈME: Le nombre %v est utilisé sans explication.
+
+POURQUOI: Les magic numbers:
+  - N'expliquent pas leur signification
+  - Sont difficiles à modifier
+  - Rendent le code incompréhensible
+
+EXCEPTIONS: 0, 1, -1, 2 (souvent évidents)
+
+EXEMPLE INCORRECT:
+  if age < 18 { ... }
+  time.Sleep(30 * time.Second)
+
+EXEMPLE CORRECT:
+  const MajorityAge = 18
+  const DefaultTimeout = 30 * time.Second
+  if age < MajorityAge { ... }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-010",
+		Short: "naked return interdit (fonction > 5 lignes)",
+		Verbose: `PROBLÈME: Return sans valeur dans fonction longue.
+
+POURQUOI: Les naked returns:
+  - Cachent ce qui est retourné
+  - Rendent le debugging difficile
+  - Sont source de bugs subtils
+
+EXCEPTION: Autorisé pour fonctions < 5 lignes.
+
+EXEMPLE INCORRECT:
+  func GetUser(id int) (user *User, err error) {
+      user, err = db.Find(id)
+      return  // Que retourne-t-on?
+  }
+
+EXEMPLE CORRECT:
+  func GetUser(id int) (*User, error) {
+      user, err := db.Find(id)
+      return user, err
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-011",
+		Short: "complexité cyclomatique %d (max 15). Simplifier",
+		Verbose: `PROBLÈME: Complexité cyclomatique de %d (max 15).
+
+POURQUOI: Complexité élevée signifie:
+  - Trop de chemins d'exécution
+  - Difficile à tester
+  - Difficile à maintenir
+
+CALCUL: +1 pour if, else, case, for, &&, ||
+
+SOLUTIONS:
+  - Extraire des sous-fonctions
+  - Utiliser early returns
+  - Remplacer switch par map`,
+	})
+
+	Register(Message{
+		Code:  "KTN-FUNC-012",
+		Short: "%d retours sans noms. Named returns requis pour >3 valeurs",
+		Verbose: `PROBLÈME: La fonction retourne %d valeurs sans noms.
+
+POURQUOI: Pour >3 retours, les noms:
+  - Documentent chaque position
+  - Facilitent la lecture
+  - Servent de documentation
+
+EXEMPLE INCORRECT:
+  func Parse() (string, int, bool, []string, error)
+
+EXEMPLE CORRECT:
+  func Parse() (path string, port int, debug bool, hosts []string, err error)`,
+	})
+}

--- a/pkg/messages/interface.go
+++ b/pkg/messages/interface.go
@@ -1,0 +1,21 @@
+// Interface messages for KTN-INTERFACE rules.
+package messages
+
+// registerInterfaceMessages enregistre les messages INTERFACE.
+func registerInterfaceMessages() {
+	Register(Message{
+		Code:  "KTN-INTERFACE-001",
+		Short: "interface privée '%s' non utilisée (code mort)",
+		Verbose: `PROBLÈME: L'interface privée '%s' n'est utilisée nulle part.
+
+POURQUOI: Une interface non utilisée:
+  - Est du code mort
+  - Alourdit la maintenance
+  - Induit en erreur
+
+ACTIONS:
+  - Si prévue pour plus tard → supprimer (git la garde)
+  - Si oubliée après refactoring → supprimer
+  - Si utilisée par réflexion → annoter avec commentaire`,
+	})
+}

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -1,0 +1,108 @@
+// Package messages provides structured error messages for KTN rules.
+// Each rule has a short message (default) and a verbose message (--verbose).
+package messages
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Message contient les messages court et verbose pour une règle.
+type Message struct {
+	Code    string
+	Short   string
+	Verbose string
+}
+
+// Format retourne le message approprié selon le mode verbose.
+//
+// Params:
+//   - verbose: true pour le message détaillé
+//   - args: arguments pour le formatage
+//
+// Returns:
+//   - string: message formaté
+func (m Message) Format(verbose bool, args ...any) string {
+	// Sélectionner le template
+	template := m.Short
+	// Vérifier si mode verbose
+	if verbose && m.Verbose != "" {
+		template = m.Verbose
+	}
+
+	// Formater avec les arguments
+	if len(args) > 0 {
+		// Appliquer le formatage
+		return fmt.Sprintf(template, args...)
+	}
+
+	// Retour du template sans formatage
+	return template
+}
+
+// FormatShort retourne le message court avec suffixe --verbose.
+//
+// Params:
+//   - args: arguments pour le formatage
+//
+// Returns:
+//   - string: message court formaté
+func (m Message) FormatShort(args ...any) string {
+	msg := m.Format(false, args...)
+	// Ajouter le suffixe si verbose disponible
+	if m.Verbose != "" && !strings.HasSuffix(msg, "(--verbose pour détails)") {
+		msg += " (--verbose pour détails)"
+	}
+	// Retour du message
+	return msg
+}
+
+// FormatVerbose retourne le message verbose complet.
+//
+// Params:
+//   - args: arguments pour le formatage
+//
+// Returns:
+//   - string: message verbose formaté
+func (m Message) FormatVerbose(args ...any) string {
+	// Retour du message verbose
+	return m.Format(true, args...)
+}
+
+// registry stocke tous les messages par code de règle.
+var registry = make(map[string]Message)
+
+// Register enregistre un message pour une règle.
+//
+// Params:
+//   - msg: message à enregistrer
+func Register(msg Message) {
+	registry[msg.Code] = msg
+}
+
+// Get récupère un message par code de règle.
+//
+// Params:
+//   - code: code de la règle (ex: KTN-FUNC-001)
+//
+// Returns:
+//   - Message: message trouvé ou vide
+//   - bool: true si trouvé
+func Get(code string) (Message, bool) {
+	msg, ok := registry[code]
+	// Retour du résultat
+	return msg, ok
+}
+
+// init enregistre tous les messages.
+func init() {
+	// Enregistrer tous les messages
+	registerCommentMessages()
+	registerConstMessages()
+	registerFuncMessages()
+	registerStructMessages()
+	registerTestMessages()
+	registerVarMessages()
+	registerInterfaceMessages()
+	registerReturnMessages()
+}

--- a/pkg/messages/return.go
+++ b/pkg/messages/return.go
@@ -1,0 +1,30 @@
+// Return messages for KTN-RETURN rules.
+package messages
+
+// registerReturnMessages enregistre les messages RETURN.
+func registerReturnMessages() {
+	Register(Message{
+		Code:  "KTN-RETURN-002",
+		Short: "retourne nil au lieu de %s vide. Préférer %s{}",
+		Verbose: `PROBLÈME: La fonction retourne nil au lieu de %s vide.
+
+POURQUOI: nil peut causer des nil pointer dereferences.
+Une collection vide est itérable sans vérification.
+
+EXEMPLE INCORRECT:
+  func GetUsers() []User {
+      if noUsers {
+          return nil  // Danger!
+      }
+  }
+
+EXEMPLE CORRECT:
+  func GetUsers() []User {
+      if noUsers {
+          return []User{}  // Vide mais safe
+      }
+  }
+
+NOTE: for range sur nil est OK, mais len() peut surprendre.`,
+	})
+}

--- a/pkg/messages/struct.go
+++ b/pkg/messages/struct.go
@@ -1,0 +1,160 @@
+// Struct messages for KTN-STRUCT rules.
+package messages
+
+// registerStructMessages enregistre les messages STRUCT.
+func registerStructMessages() {
+	Register(Message{
+		Code:  "KTN-STRUCT-001",
+		Short: "struct '%s' a %d méthode(s) publique(s) sans interface",
+		Verbose: `PROBLÈME: La struct '%s' a %d méthode(s) sans interface.
+
+POURQUOI: Une interface permet:
+  - Le mocking dans les tests
+  - L'injection de dépendances
+  - Le découplage
+
+SOLUTIONS:
+  1. Interface locale: créer dans le même fichier
+  2. Cross-package: var _ port.I = (*%s)(nil)
+
+EXCEPTIONS AUTOMATIQUES:
+  - DTOs (tags json/xml/yaml)
+  - Consumers (champs de type interface)
+
+EXEMPLE SOLUTION 1:
+  type UserRepository interface {
+      GetByID(id int) (*User, error)
+  }
+  type userRepositoryImpl struct { ... }
+
+EXEMPLE SOLUTION 2 (cross-package):
+  var _ port.UserRepository = (*UserRepositoryImpl)(nil)`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-002",
+		Short: "struct '%s' sans constructeur New%s()",
+		Verbose: `PROBLÈME: La struct '%s' n'a pas de constructeur.
+
+POURQUOI: Un constructeur:
+  - Initialise correctement
+  - Documente les dépendances
+  - Permet la validation
+  - Évite structs mal initialisées
+
+EXEMPLE INCORRECT:
+  type Service struct { repo Repository }
+  // &Service{} → repo est nil!
+
+EXEMPLE CORRECT:
+  func NewService(repo Repository) *Service {
+      return &Service{repo: repo}
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-003",
+		Short: "méthode '%s' utilise Get. Convention Go: %s() pas Get%s()",
+		Verbose: `PROBLÈME: La méthode '%s' utilise le préfixe 'Get'.
+
+POURQUOI: Convention Go idiomatique:
+  - Getter: Name() pas GetName()
+  - Setter: SetName(v) (Set requis)
+
+Effective Go: "It's neither idiomatic nor necessary
+to put Get into the getter's name."
+
+EXEMPLE INCORRECT:
+  func (u *User) GetName() string
+
+EXEMPLE CORRECT:
+  func (u *User) Name() string
+  func (u *User) SetName(name string)`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-004",
+		Short: "fichier avec %d structs. Une struct par fichier",
+		Verbose: `PROBLÈME: Le fichier contient %d structs (max 1).
+
+POURQUOI: Une struct par fichier:
+  - Facilite navigation (nom fichier = struct)
+  - Évite fichiers de 1000+ lignes
+  - Simplifie les reviews
+  - Principe de responsabilité unique
+
+EXCEPTION: Structs auxiliaires privées très liées.
+
+SOLUTION: Créer un fichier par struct.
+  user.go           → type User struct
+  user_repository.go → type UserRepository struct`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-005",
+		Short: "champs privés avant publics. Exportés d'abord",
+		Verbose: `PROBLÈME: Champs privés avant champs publics.
+
+POURQUOI: Les champs exportés = API publique.
+Les mettre en premier facilite la lecture.
+
+ORDRE ATTENDU:
+  1. Champs exportés (Majuscule)
+  2. Champs privés (minuscule)
+
+EXEMPLE INCORRECT:
+  type User struct {
+      password string  // Privé
+      Name     string  // Exporté après!
+  }
+
+EXEMPLE CORRECT:
+  type User struct {
+      Name     string  // Exportés d'abord
+      Email    string
+      password string  // Puis privés
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-006",
+		Short: "champ privé '%s' avec tag de sérialisation inutile",
+		Verbose: `PROBLÈME: Le champ privé '%s' a un tag json/xml/yaml.
+
+POURQUOI: Les champs privés ne sont PAS sérialisés.
+Le tag est donc inutile et trompeur.
+
+EXEMPLE INCORRECT:
+  type User struct {
+      name string ` + "`json:\"name\"`" + `  // Ignoré!
+  }
+
+EXEMPLE CORRECT (exporter):
+  type User struct {
+      Name string ` + "`json:\"name\"`" + `
+  }
+
+EXEMPLE CORRECT (garder privé):
+  type User struct {
+      name string  // Pas de tag
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-STRUCT-007",
+		Short: "getter '%s' devrait être '%s' pour champ '%s'",
+		Verbose: `PROBLÈME: Le getter '%s' ne suit pas la convention.
+
+CONVENTION GO:
+  - Champ: name
+  - Getter: Name() (pas GetName())
+  - Setter: SetName(v)
+
+EXEMPLE INCORRECT:
+  func (u *User) GetName() string
+
+EXEMPLE CORRECT:
+  func (u *User) Name() string
+  func (u *User) SetName(name string)`,
+	})
+}

--- a/pkg/messages/test.go
+++ b/pkg/messages/test.go
@@ -1,0 +1,131 @@
+// Test messages for KTN-TEST rules.
+package messages
+
+// registerTestMessages enregistre les messages TEST.
+func registerTestMessages() {
+	Register(Message{
+		Code:  "KTN-TEST-002",
+		Short: "package test incorrect '%s'. Utiliser '%s_test'",
+		Verbose: `PROBLÈME: Le fichier test utilise le package '%s'.
+
+POURQUOI: Les tests doivent utiliser le package xxx_test
+pour du black-box testing (tester l'API publique).
+
+EXEMPLE INCORRECT:
+  package mypackage  // Même package = white-box
+
+EXEMPLE CORRECT:
+  package mypackage_test  // Black-box testing`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-004",
+		Short: "fonction '%s' sans test correspondant",
+		Verbose: `PROBLÈME: La fonction '%s' n'a pas de test.
+
+POURQUOI: Chaque fonction doit avoir un test pour:
+  - Documenter le comportement attendu
+  - Prévenir les régressions
+  - Faciliter le refactoring
+
+FORMAT ATTENDU:
+  - Publique: TestNomFonction dans *_external_test.go
+  - Privée: Test_nomFonction dans *_internal_test.go`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-005",
+		Short: "test '%s' sans table-driven pattern",
+		Verbose: `PROBLÈME: Le test '%s' n'utilise pas table-driven.
+
+POURQUOI: Le pattern table-driven:
+  - Facilite l'ajout de cas
+  - Rend les tests lisibles
+  - Évite la duplication
+
+EXEMPLE:
+  func TestAdd(t *testing.T) {
+      tests := []struct {
+          name     string
+          a, b     int
+          expected int
+      }{
+          {"positifs", 1, 2, 3},
+          {"négatifs", -1, -1, -2},
+      }
+      for _, tt := range tests {
+          t.Run(tt.name, func(t *testing.T) {
+              got := Add(tt.a, tt.b)
+              if got != tt.expected {
+                  t.Errorf("got %d, want %d", got, tt.expected)
+              }
+          })
+      }
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-007",
+		Short: "t.Skip() interdit dans '%s'. Les tests doivent passer",
+		Verbose: `PROBLÈME: Le test '%s' utilise t.Skip().
+
+POURQUOI: t.Skip() cache des tests cassés:
+  - Les tests doivent toujours passer
+  - Un test skipé est souvent oublié
+  - Si le test n'est plus valide, le supprimer
+
+ALTERNATIVES:
+  - Fixer le test
+  - Utiliser build tags pour environnements spécifiques
+  - Supprimer si obsolète`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-008",
+		Short: "fichier '%s' sans tests. Créer %s",
+		Verbose: `PROBLÈME: Le fichier '%s' n'a pas de fichier test.
+
+POURQUOI: Chaque fichier .go doit avoir ses tests.
+
+FICHIERS À CRÉER:
+  - %s_external_test.go (package xxx_test, black-box)
+  - %s_internal_test.go (package xxx, white-box) si privés
+
+CONVENTION:
+  - Fonctions publiques → external_test.go
+  - Fonctions privées → internal_test.go`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-012",
+		Short: "test '%s' sans assertions. Un test doit tester",
+		Verbose: `PROBLÈME: Le test '%s' ne contient pas d'assertions.
+
+POURQUOI: Un test sans assertion:
+  - Ne vérifie rien
+  - Passe toujours (faux positif)
+  - Est inutile
+
+UN TEST DOIT CONTENIR:
+  - t.Error/t.Errorf
+  - t.Fatal/t.Fatalf
+  - Comparaisons avec expected`,
+	})
+
+	Register(Message{
+		Code:  "KTN-TEST-013",
+		Short: "test '%s' ne couvre pas les cas d'erreur",
+		Verbose: `PROBLÈME: Le test '%s' ne teste pas les erreurs.
+
+POURQUOI: Les cas d'erreur:
+  - Sont souvent les plus critiques
+  - Révèlent des bugs de gestion
+  - Documentent le comportement d'erreur
+
+À TESTER:
+  - Paramètres invalides
+  - Ressources indisponibles
+  - Limites dépassées
+  - nil/zero values`,
+	})
+}

--- a/pkg/messages/var.go
+++ b/pkg/messages/var.go
@@ -1,0 +1,343 @@
+// Var messages for KTN-VAR rules.
+package messages
+
+// registerVarMessages enregistre les messages VAR.
+func registerVarMessages() {
+	Register(Message{
+		Code:  "KTN-VAR-001",
+		Short: "variable '%s' utilise SCREAMING_SNAKE. Utiliser camelCase",
+		Verbose: `PROBLÈME: La variable '%s' utilise SCREAMING_SNAKE_CASE.
+
+POURQUOI: Go utilise camelCase pour tout, y compris variables.
+
+EXEMPLE INCORRECT:
+  var MAX_SIZE = 1024
+  var DEFAULT_TIMEOUT = 30
+
+EXEMPLE CORRECT:
+  var maxSize = 1024       // Privée
+  var DefaultTimeout = 30  // Exportée`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-002",
+		Short: "variable '%s' sans type explicite. Format: var name Type = value",
+		Verbose: `PROBLÈME: La variable de package '%s' n'a pas de type.
+
+POURQUOI: Le type explicite:
+  - Documente l'intention
+  - Évite les conversions implicites
+
+FORMAT ATTENDU:
+  var nomVariable Type = valeur
+
+EXEMPLE INCORRECT:
+  var timeout = 30
+
+EXEMPLE CORRECT:
+  var timeout time.Duration = 30 * time.Second`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-003",
+		Short: "utiliser := au lieu de var pour variable locale",
+		Verbose: `PROBLÈME: 'var' utilisé pour une variable locale.
+
+POURQUOI: En Go, := est préféré pour les variables locales:
+  - Plus concis
+  - Idiomatique
+  - Le type est inféré
+
+EXEMPLE INCORRECT:
+  var x int = 42
+  var err error = nil
+
+EXEMPLE CORRECT:
+  x := 42
+  var err error  // OK si zero value voulue`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-004",
+		Short: "slice non préallouée. Utiliser make([]T, 0, %d)",
+		Verbose: `PROBLÈME: La slice n'est pas préallouée malgré capacité connue.
+
+POURQUOI: Sans préallocation, append() réalloue à chaque dépassement,
+causant des copies et de la pression GC.
+
+EXEMPLE INCORRECT:
+  var items []Item
+  for _, x := range data {
+      items = append(items, x)
+  }
+
+EXEMPLE CORRECT:
+  items := make([]Item, 0, len(data))
+  for _, x := range data {
+      items = append(items, x)
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-005",
+		Short: "make([]T, %d) avec append cause réallocation. Utiliser cap",
+		Verbose: `PROBLÈME: make([]T, n) crée n éléments, append en ajoute après.
+
+POURQUOI: make([]T, n) initialise à zéro, append ajoute EN PLUS.
+  make([]T, 5) puis append(s, x) → len=6, pas len=5!
+
+EXEMPLE INCORRECT:
+  s := make([]int, 10)
+  s = append(s, 42)  // len=11!
+
+EXEMPLE CORRECT:
+  s := make([]int, 0, 10)
+  s = append(s, 42)  // len=1, cap=10`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-006",
+		Short: "Buffer/Builder sans Grow(). Préallouer avec Grow(%d)",
+		Verbose: `PROBLÈME: bytes.Buffer ou strings.Builder sans Grow().
+
+POURQUOI: Sans Grow(), le buffer réalloue à chaque dépassement.
+
+EXEMPLE INCORRECT:
+  var buf bytes.Buffer
+  for _, s := range items {
+      buf.WriteString(s)
+  }
+
+EXEMPLE CORRECT:
+  var buf bytes.Buffer
+  buf.Grow(estimatedSize)
+  for _, s := range items {
+      buf.WriteString(s)
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-007",
+		Short: "%d concaténations string. Utiliser strings.Builder",
+		Verbose: `PROBLÈME: %d concaténations de string avec +.
+
+POURQUOI: Chaque + crée une nouvelle string (immutable).
+strings.Builder évite les allocations.
+
+EXEMPLE INCORRECT:
+  s := ""
+  for _, x := range items {
+      s += x + ","
+  }
+
+EXEMPLE CORRECT:
+  var b strings.Builder
+  for _, x := range items {
+      b.WriteString(x)
+      b.WriteString(",")
+  }
+  s := b.String()`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-008",
+		Short: "allocation dans boucle chaude. Sortir de la boucle",
+		Verbose: `PROBLÈME: Allocation répétée dans une boucle.
+
+POURQUOI: Allouer dans une boucle:
+  - Crée de la pression GC
+  - Ralentit l'exécution
+  - Peut être évité
+
+EXEMPLE INCORRECT:
+  for i := 0; i < 1000; i++ {
+      buf := make([]byte, 1024)
+      process(buf)
+  }
+
+EXEMPLE CORRECT:
+  buf := make([]byte, 1024)
+  for i := 0; i < 1000; i++ {
+      process(buf)
+      clear(buf)
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-009",
+		Short: "struct de %d bytes passée par valeur. Utiliser pointeur",
+		Verbose: `PROBLÈME: Struct de %d bytes passée par valeur (>64 bytes).
+
+POURQUOI: Passer par valeur copie toute la struct.
+Un pointeur copie seulement 8 bytes (64-bit).
+
+SEUIL: >64 bytes → utiliser pointeur
+
+EXEMPLE INCORRECT:
+  func Process(data LargeStruct) { ... }
+
+EXEMPLE CORRECT:
+  func Process(data *LargeStruct) { ... }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-010",
+		Short: "buffer répété sans sync.Pool. Utiliser Pool",
+		Verbose: `PROBLÈME: Buffers alloués/libérés en boucle.
+
+POURQUOI: sync.Pool réutilise les objets et réduit le GC.
+
+EXEMPLE INCORRECT:
+  for req := range requests {
+      buf := make([]byte, 4096)
+      process(buf)
+  }
+
+EXEMPLE CORRECT:
+  var bufPool = sync.Pool{
+      New: func() any { return make([]byte, 4096) },
+  }
+  for req := range requests {
+      buf := bufPool.Get().([]byte)
+      process(buf)
+      bufPool.Put(buf)
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-011",
+		Short: "shadowing de '%s' avec :=. Utiliser = pour réassigner",
+		Verbose: `PROBLÈME: La variable '%s' est shadowée avec :=.
+
+POURQUOI: := crée une NOUVELLE variable qui cache l'ancienne.
+C'est souvent un bug subtil.
+
+EXEMPLE INCORRECT:
+  x := 10
+  if cond {
+      x := 20  // Nouvelle variable, shadow!
+  }
+  // x est toujours 10
+
+EXEMPLE CORRECT:
+  x := 10
+  if cond {
+      x = 20  // Réassignation
+  }
+  // x est 20`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-012",
+		Short: "string() appelé %d fois sur même valeur. Stocker le résultat",
+		Verbose: `PROBLÈME: string() appelé plusieurs fois sur même []byte.
+
+POURQUOI: Chaque string() alloue une nouvelle string.
+
+EXEMPLE INCORRECT:
+  if string(data) == "foo" || string(data) == "bar" { }
+
+EXEMPLE CORRECT:
+  s := string(data)
+  if s == "foo" || s == "bar" { }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-013",
+		Short: "variables non groupées. Utiliser un seul bloc var()",
+		Verbose: `PROBLÈME: Plusieurs blocs var séparés.
+
+POURQUOI: Grouper améliore la lisibilité et la cohérence.
+
+EXEMPLE INCORRECT:
+  var x int = 1
+  var y int = 2
+  var z int = 3
+
+EXEMPLE CORRECT:
+  var (
+      x int = 1
+      y int = 2
+      z int = 3
+  )`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-014",
+		Short: "var avant const. Ordre: const → var → type → func",
+		Verbose: `PROBLÈME: bloc var déclaré avant bloc const.
+
+POURQUOI: L'ordre standard facilite la navigation:
+  1. const
+  2. var
+  3. type
+  4. func`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-015",
+		Short: "map sans capacité. Utiliser make(map[K]V, %d)",
+		Verbose: `PROBLÈME: Map créée sans capacité initiale connue.
+
+POURQUOI: Sans capacité, la map réalloue en grandissant.
+
+EXEMPLE INCORRECT:
+  m := make(map[string]int)
+  for _, item := range items {  // len(items) connu
+      m[item.Key] = item.Val
+  }
+
+EXEMPLE CORRECT:
+  m := make(map[string]int, len(items))`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-016",
+		Short: "make([]T, %d) pour taille fixe. Utiliser [%d]T",
+		Verbose: `PROBLÈME: make() pour une taille constante connue à la compilation.
+
+POURQUOI: Un array [N]T est sur la stack (pas d'allocation heap).
+
+EXEMPLE INCORRECT:
+  buf := make([]byte, 32)  // Heap allocation
+
+EXEMPLE CORRECT:
+  var buf [32]byte  // Stack allocation`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-017",
+		Short: "copie de mutex '%s'. Utiliser pointeur ou embed",
+		Verbose: `PROBLÈME: sync.Mutex/RWMutex copié par valeur.
+
+POURQUOI: Copier un mutex copie son état interne,
+causant des deadlocks ou data races.
+
+EXEMPLE INCORRECT:
+  func process(m sync.Mutex) { ... }  // Copie!
+
+EXEMPLE CORRECT:
+  func process(m *sync.Mutex) { ... }
+  // Ou embed dans struct:
+  type Safe struct {
+      mu sync.Mutex
+      data int
+  }`,
+	})
+
+	Register(Message{
+		Code:  "KTN-VAR-018",
+		Short: "variable '%s' utilise snake_case. Utiliser camelCase",
+		Verbose: `PROBLÈME: La variable '%s' utilise snake_case.
+
+POURQUOI: Go utilise camelCase pour toutes les variables.
+
+EXEMPLE INCORRECT:
+  var user_name string
+  var max_size int
+
+EXEMPLE CORRECT:
+  var userName string
+  var maxSize int`,
+	})
+}


### PR DESCRIPTION
## Summary
- Nouveau package `pkg/messages` avec définitions messages court/verbose pour toutes les règles
- Le formatter accepte maintenant un paramètre `verboseMode`
- En mode verbose, les messages multi-lignes sont affichés complètement
- Le flag `--verbose` affecte l'affichage des messages

## Utilisation

```bash
# Mode normal (messages courts)
ktn-linter lint ./...

# Mode verbose (messages détaillés avec exemples)
ktn-linter lint --verbose ./...
```

## Prochaine étape
Mettre à jour chaque règle pour utiliser le package messages et générer des messages multi-lignes.

## Test plan
- [x] Tests passent
- [x] Mode verbose testé manuellement
- [x] Infrastructure prête pour intégration dans les règles

🤖 Generated with [Claude Code](https://claude.com/claude-code)