### PR TITLE
fix: update golangci-lint config for v2 and fix wrapper

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,31 +4,9 @@ run:
   timeout: 5m
   tests: true
   go: "1.25.5"
-  # Inclure les fichiers testdata dans l'analyse
-  build-tags: []
-  skip-dirs: []
-  skip-files: []
 
 # Configuration minimale : uniquement KTN-Linter via make lint
 # Aucun linter golangci-lint activé
 linters:
+  default: none
   enable: []
-  disable-all: true
-
-issues:
-  max-issues-per-linter: 0
-  max-same-issues: 0
-  # Ne pas exclure testdata
-  exclude-dirs: []
-  # Exclure les fichiers _test.go du linting KTN
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - all
-  # Désactiver les diagnostics natifs de Go (redeclarations, unused vars, etc.)
-  exclude-use-default: false
-  exclude:
-    - ".*other declaration.*"
-    - ".*declared and not used.*"
-    - ".*imported and not used.*"
-    - ".*no new variables.*"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,8 @@
 {
+  // JSON Schema pour golangci-lint v2
+  "yaml.schemas": {
+    "https://golangci-lint.run/jsonschema/golangci.v2.jsonschema.json": ".golangci.yml"
+  },
   // Configuration KTN-Linter via wrapper
   "go.lintTool": "golangci-lint",
   "go.lintOnSave": "off",

--- a/bin/golangci-lint-wrapper
+++ b/bin/golangci-lint-wrapper
@@ -3,6 +3,7 @@
 # Transparently runs both linters and combines results
 
 LINTER_BIN="/workspace/builds/ktn-linter"
+CONFIG_FILE="/workspace/.golangci.yml"
 
 # Ensure ktn-linter is installed
 if [ ! -f "$LINTER_BIN" ]; then
@@ -19,17 +20,26 @@ REAL_GOLANGCI_LINT="/usr/local/bin/golangci-lint"
 # Temporary file for combined output
 TEMP_OUTPUT=$(mktemp)
 
-# Run real golangci-lint if it exists and we have standard arguments
-if [ -x "$REAL_GOLANGCI_LINT" ] && [[ "$*" != *"testdata"* ]]; then
-    # Execute real golangci-lint with all original arguments
+# Check if golangci-lint has any linters enabled
+# Skip if config has "default: none" and "enable: []"
+RUN_GOLANGCI=false
+if [ -x "$REAL_GOLANGCI_LINT" ] && [ -f "$CONFIG_FILE" ]; then
+    # Check if any linters are enabled (not "enable: []")
+    if grep -q "enable: \[" "$CONFIG_FILE" && ! grep -q "enable: \[\]" "$CONFIG_FILE"; then
+        RUN_GOLANGCI=true
+    fi
+fi
+
+# Run real golangci-lint only if linters are enabled
+if [ "$RUN_GOLANGCI" = true ] && [[ "$*" != *"testdata"* ]]; then
     "$REAL_GOLANGCI_LINT" "$@" 2>&1 >> "$TEMP_OUTPUT" || true
 fi
 
 # Filtrer les arguments golangci-lint pour garder uniquement les packages/chemins
 TARGETS=()
 for arg in "$@"; do
-    # Ignorer les flags golangci-lint
-    if [[ ! "$arg" =~ ^- ]]; then
+    # Ignorer les flags golangci-lint et la commande "run"
+    if [[ ! "$arg" =~ ^- ]] && [[ "$arg" != "run" ]]; then
         TARGETS+=("$arg")
     fi
 done
@@ -37,18 +47,18 @@ done
 # Run KTN-Linter
 if [ ${#TARGETS[@]} -eq 0 ]; then
     # Scanner le projet principal
-    "$LINTER_BIN" lint --simple --no-color ./... 2>&1 >> "$TEMP_OUTPUT" || true
+    "$LINTER_BIN" lint ./... 2>&1 >> "$TEMP_OUTPUT" || true
 
     # Scanner tous les packages testdata (qui ne sont pas inclus dans ./...)
     find ./pkg/analyzer/ktn/*/testdata/src/* -maxdepth 1 -type d 2>/dev/null | while IFS= read -r dir; do
         # Vérifier si le répertoire contient des fichiers .go
         if compgen -G "$dir/*.go" > /dev/null 2>&1; then
-            "$LINTER_BIN" lint --simple --no-color "$dir" 2>&1 >> "$TEMP_OUTPUT" || true
+            "$LINTER_BIN" lint "$dir" 2>&1 >> "$TEMP_OUTPUT" || true
         fi
     done
 else
     # Exécuter le linter sur les cibles spécifiées
-    "$LINTER_BIN" lint --simple --no-color "${TARGETS[@]}" 2>&1 >> "$TEMP_OUTPUT" || true
+    "$LINTER_BIN" lint "${TARGETS[@]}" 2>&1 >> "$TEMP_OUTPUT" || true
 fi
 
 # Output combined results


### PR DESCRIPTION
## Summary
- Update `.golangci.yml` to use golangci-lint v2 format (was using v1 syntax)
- Set Go version to 1.25.5
- Add JSON schema reference in VS Code settings for config validation
- Update wrapper to use new ktn-linter CLI (removed `--simple`/`--no-color` flags)
- Skip golangci-lint when no linters are enabled in config

## Test plan
- [x] `make test` passes
- [x] `make build` succeeds
- [x] Wrapper runs ktn-linter correctly via `golangci-lint-wrapper run ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)