### PR TITLE
fix(config): restore clean .golangci.yml configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ version: "2"
 run:
   timeout: 5m
   tests: true
-  go: "1.25.5"
 
 # Configuration minimale : uniquement KTN-Linter via make lint
 # Aucun linter golangci-lint activé


### PR DESCRIPTION
## Summary
- Remove workaround attempts for golangci-lint Go 1.25 compatibility issue
- Restore clean configuration with `tests: true`

The wrapper script (`bin/golangci-lint-wrapper`) handles linting via ktn-linter, bypassing golangci-lint's internal typecheck issues with Go 1.25 toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)