### PR TITLE
fix(testdata): normalize package comments to Go conventions

### DIFF
--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment001/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the comment001 test case.
+// Package comment001 contains test cases for KTN rules.
 package comment001
 
 const (

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment001/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the comment001 test case.
+// Package comment001 provides good test cases.
 package comment001
 
 const (

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment003/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment003/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the const002 test case.
+// Package comment003 contains test cases for KTN rules.
 package comment003
 
 const (

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment003/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment003/good.go
@@ -1,4 +1,4 @@
-// Good examples for the const002 test case.
+// Package comment003 provides good test cases.
 package comment003
 
 // Good: All constants have comments, explicit types, proper naming, single-block grouping

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment004/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment004/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var002 test case.
+// Package comment004 contains test cases for KTN rules.
 package comment004
 
 const (

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment004/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment004/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var002 test case.
+// Package comment004 provides good test cases.
 package comment004
 
 // Good: All variables have comments, explicit types, proper naming, single-block grouping

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment005/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment005/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct004 test case.
+// Package comment005 contains test cases for KTN rules.
 package comment005
 
 // BadUser documentation insuffisante (1 seule ligne) - VIOLATION

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment005/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment005/good.go
@@ -1,4 +1,4 @@
-// Good examples for the struct004 test case.
+// Package comment005 provides good test cases.
 package comment005
 
 // User représente un utilisateur du système.

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment006/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment006/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the comment006 test case.
+// Package comment006 contains test cases for KTN rules.
 package comment006
 
 // badNoDoc n'a aucune documentation.

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment006/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment006/good.go
@@ -1,4 +1,4 @@
-// Good examples for the comment006 test case.
+// Package comment006 provides good test cases.
 package comment006
 
 // GoodNoParams effectue une action simple sans paramètres.

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment007/bad.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment007/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func009 test case.
+// Package comment007 contains test cases for KTN rules.
 package comment007
 
 // Bad: Missing comments on branches and returns

--- a/pkg/analyzer/ktn/ktncomment/testdata/src/comment007/good.go
+++ b/pkg/analyzer/ktn/ktncomment/testdata/src/comment007/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func009 test case.
+// Package comment007 provides good test cases.
 package comment007
 
 // Good: All branches and returns have comments

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const001/bad.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the const001 test case.
+// Package const001 contains test cases for KTN rules.
 package const001
 
 // Bad: All constants WITHOUT explicit types (violates KTN-CONST-001)

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const001/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the const001 test case.
+// Package const001 provides good test cases.
 package const001
 
 // Good: All constants in a single grouped block with explicit types

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const002/bad.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const002/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the const002 test case.
+// Package const002 contains test cases for KTN rules.
 package const002
 
 // First const block (OK - at the top)

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const002/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const002/good.go
@@ -1,4 +1,4 @@
-// Good examples for the const002 test case.
+// Package const002 provides good test cases.
 package const002
 
 // Good: All constants grouped in a single block at the very top

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const003/bad.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const003/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the const003 test case.
+// Package const003 contains test cases for KTN rules.
 package const003
 
 // Bad: Invalid naming (violates KTN-CONST-003)

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const003/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const003/good.go
@@ -1,4 +1,4 @@
-// Good examples for the const003 test case.
+// Package const003 provides good test cases.
 package const003
 
 // Good: All constants use CamelCase naming (Go standard)

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func001/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func001 test case.
+// Package func001 contains test cases for KTN rules.
 package func001
 
 // Bad examples: error is not last

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func001/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func001 test case.
+// Package func001 provides good test cases.
 package func001
 
 // Good examples: error is always last

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func002/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func002/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func002 test case.
+// Package func002 contains test cases for KTN rules.
 package func002
 
 import "context"

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func003/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func003/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func003 test case.
+// Package func003 contains test cases for KTN rules.
 package func003
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func003/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func003/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func003 test case.
+// Package func003 provides good test cases.
 package func003
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func005/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func005/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func005 test case.
+// Package func005 contains test cases for KTN rules.
 package func005
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func005/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func005/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func005 test case.
+// Package func005 provides good test cases.
 package func005
 
 // Constantes pour éviter les magic numbers

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func006/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func006/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func006 test case.
+// Package func006 contains test cases for KTN rules.
 package func006
 
 import "context"

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func007/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func007/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func008 test case.
+// Package func007 contains test cases for KTN rules.
 package func007
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func007/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func007/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func008 test case.
+// Package func007 provides good test cases.
 package func007
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func008/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func008/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func008 test case.
+// Package func008 contains test cases for KTN rules.
 package func008
 
 import "context"

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func008/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func008/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func008 test case.
+// Package func008 provides good test cases.
 package func008
 
 import "context"

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func009/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func009/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func011 test case.
+// Package func009 contains test cases for KTN rules.
 package func009
 
 // badProcessSixItems creates a slice with magic number 6 (violates KTN-FUNC-009).

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func009/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func009/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func011 test case.
+// Package func009 provides good test cases.
 package func009
 
 // Constantes bien définies

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func010/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func010/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func012 test case.
+// Package func010 contains test cases for KTN rules.
 package func010
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func010/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func010/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func012 test case.
+// Package func010 provides good test cases.
 package func010
 
 import "unsafe"

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func011/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func011/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func011 test case.
+// Package func011 contains test cases for KTN rules.
 package func011
 
 // Constants used in complexity tests

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func011/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func011/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func013 test case.
+// Package func011 provides good test cases.
 package func011
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func012/bad.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func012/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the func014 test case.
+// Package func012 contains test cases for KTN rules.
 package func012
 
 const (

--- a/pkg/analyzer/ktn/ktnfunc/testdata/src/func012/good.go
+++ b/pkg/analyzer/ktn/ktnfunc/testdata/src/func012/good.go
@@ -1,4 +1,4 @@
-// Good examples for the func014 test case.
+// Package func012 provides good test cases.
 package func012
 
 const (

--- a/pkg/analyzer/ktn/ktninterface/testdata/src/interface001/bad.go
+++ b/pkg/analyzer/ktn/ktninterface/testdata/src/interface001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the interface001 test case.
+// Package interface001 contains test cases for KTN rules.
 package interface001
 
 // badUnusedInterface is never used anywhere.

--- a/pkg/analyzer/ktn/ktninterface/testdata/src/interface001/good.go
+++ b/pkg/analyzer/ktn/ktninterface/testdata/src/interface001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the interface001 test case.
+// Package interface001 provides good test cases.
 package interface001
 
 // goodUsedInterface is used in function parameter.

--- a/pkg/analyzer/ktn/ktnreturn/testdata/src/return001/bad.go
+++ b/pkg/analyzer/ktn/ktnreturn/testdata/src/return001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the return002 test case.
+// Package return001 contains test cases for KTN rules.
 package return002
 
 // badReturnNilSlice returns nil for a slice type.

--- a/pkg/analyzer/ktn/ktnreturn/testdata/src/return001/good.go
+++ b/pkg/analyzer/ktn/ktnreturn/testdata/src/return001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the return002 test case.
+// Package return001 provides good test cases.
 package return002
 
 const (

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/bad.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct001 test case.
+// Package struct001 contains test cases for KTN-STRUCT-001.
 package struct001
 
 // BadGetterMismatch est une struct avec un getter mal nommé.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct001/good.go
@@ -1,4 +1,3 @@
-// Good examples for the struct001 test case.
 package struct001
 
 // GoodService est une struct avec getter correctement nommé.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct002/bad.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct002/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct005 test case.
+// Package struct002 contains test cases for KTN rules.
 package struct002
 
 // BadUserService est un service utilisateur sans constructeur.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct002/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct002/good.go
@@ -1,4 +1,4 @@
-// Good examples for the struct005 test case.
+// Package struct002 provides good test cases.
 package struct002
 
 const (

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct004/bad.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct004/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct001 test case.
+// Package struct004 contains test cases for KTN rules.
 package struct004
 
 // BadProduct représente un produit de test.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct004/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct004/good.go
@@ -1,4 +1,4 @@
-// Good examples for the struct001 test case.
+// Package struct004 provides good test cases.
 package struct004
 
 // User représente un utilisateur avec une seule struct par fichier.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct005/bad.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct005/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct003 test case.
+// Package struct005 contains test cases for KTN rules.
 package struct005
 
 // BadMixedFields représente une struct avec mauvais ordre des champs.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct005/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct005/good.go
@@ -1,4 +1,4 @@
-// Good examples for the struct003 test case.
+// Package struct005 provides good test cases.
 package struct005
 
 // UserModel champs exportés avant privés - CONFORME.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct006/bad.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct006/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the struct006 test case.
+// Package struct006 contains test cases for KTN rules.
 package struct006
 
 // BadUserDTO est un DTO avec un champ privé tagué.

--- a/pkg/analyzer/ktn/ktnstruct/testdata/src/struct006/good.go
+++ b/pkg/analyzer/ktn/ktnstruct/testdata/src/struct006/good.go
@@ -1,4 +1,4 @@
-// Good examples for the struct006 test case.
+// Package struct006 provides good test cases.
 package struct006
 
 // GoodUserDTO est un DTO avec seulement des champs publics tagués.

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var001/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var001/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var001 test case.
+// Package var001 contains test cases for KTN rules.
 package var001
 
 // Bad: Package-level variables using SCREAMING_SNAKE_CASE (violates KTN-VAR-001)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var001/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var001/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var001 test case.
+// Package var001 provides good test cases.
 package var001
 
 // Good: All package-level variables use camelCase or PascalCase (not SCREAMING_SNAKE_CASE)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var002/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var002/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var002 test case.
+// Package var002 contains test cases for KTN rules.
 package var002
 
 // Bad: Variables without explicit type (violates KTN-VAR-002)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var002/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var002/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var002 test case.
+// Package var002 provides good test cases.
 package var002
 
 // Good: Variables with explicit type AND value (format: var name type = value)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var003/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var003/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var003 test case.
+// Package var003 contains test cases for KTN rules.
 package var003
 
 // Constants to avoid magic numbers

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var003/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var003/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var003 test case.
+// Package var003 provides good test cases.
 package var003
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var004/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var004/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var005 test case.
+// Package var004 contains test cases for KTN rules.
 package var004
 
 // Bad: Slices created without capacity when it could be known

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var004/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var004/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var005 test case.
+// Package var004 provides good test cases.
 package var004
 
 // Good: Slices preallocated with capacity when known

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var005/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var005/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var006 test case.
+// Package var005 provides good test cases.
 package var005
 
 // Good: Proper use of make with capacity or without length

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var006/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var006/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var007 test case.
+// Package var006 contains test cases for KTN rules.
 package var006
 
 import (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var006/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var006/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var007 test case.
+// Package var006 provides good test cases.
 package var006
 
 import (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var007/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var007/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var008 test case.
+// Package var007 contains test cases for KTN rules.
 package var007
 
 // badStringConcatInForLoop concatenates strings in a for loop.

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var007/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var007/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var008 test case.
+// Package var007 provides good test cases.
 package var007
 
 import "strings"

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var008/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var008/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var009 test case.
+// Package var008 contains test cases for KTN rules.
 package var008
 
 // Constantes pour les tests

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var008/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var008/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var009 test case.
+// Package var008 provides good test cases.
 package var008
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var009/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var009/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var010 test case.
+// Package var009 contains test cases for KTN rules.
 package var009
 
 // Constantes pour les valeurs de test

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var009/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var009/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var009 test case.
+// Package var009 provides good test cases.
 package var009
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var010/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var010/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var011 test case.
+// Package var010 contains test cases for KTN rules.
 package var010
 
 // Bad: Creating []byte buffers repeatedly in loops without sync.Pool

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var010/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var010/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var010 test case.
+// Package var010 provides good test cases.
 package var010
 
 import "sync"

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var011/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var011/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var011 test case.
+// Package var011 contains test cases for KTN rules.
 package var011
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var011/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var011/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var011 test case.
+// Package var011 provides good test cases.
 package var011
 
 import (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var012/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var012/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var012 test case.
+// Package var012 contains test cases for KTN rules.
 package var012
 
 // dataHolder contient des données en bytes.

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var012/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var012/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var012 test case.
+// Package var012 provides good test cases.
 package var012
 
 import "bytes"

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var013/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var013/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var014 test case.
+// Package var013 contains test cases for KTN rules.
 package var013
 
 // Bad: Multiple separate var declarations (violates KTN-VAR-013)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var013/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var013/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var013 test case.
+// Package var013 provides good test cases.
 package var013
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var014/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var014/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var015 test case.
+// Package var014 contains test cases for KTN rules.
 package var014
 
 // Vars come first (good placement)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var014/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var014/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var015 test case.
+// Package var014 provides good test cases.
 package var014
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var015/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var015/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var016 test case.
+// Package var015 contains test cases for KTN rules.
 package var015
 
 const (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var015/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var015/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var016 test case.
+// Package var015 provides good test cases.
 package var015
 
 // Good examples: maps with capacity hints (compliant with KTN-VAR-015)

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var016/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var016/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var017 test case.
+// Package var016 contains test cases for KTN rules.
 package var016
 
 // Bad: Using make([]T, N) where N is small constant

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var016/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var016/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var017 test case.
+// Package var016 provides good test cases.
 package var016
 
 // Good: Using arrays for small fixed sizes or slices when appropriate

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var017/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var017/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var017 test case.
+// Package var017 contains test cases for KTN rules.
 package var017
 
 import (

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var017/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var017/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var018 test case.
+// Package var017 provides good test cases.
 package var017
 
 import "sync"

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var018/bad.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var018/bad.go
@@ -1,4 +1,4 @@
-// Bad examples for the var018 test case.
+// Package var018 contains test cases for KTN rules.
 package var018
 
 // Constants to avoid magic numbers

--- a/pkg/analyzer/ktn/ktnvar/testdata/src/var018/good.go
+++ b/pkg/analyzer/ktn/ktnvar/testdata/src/var018/good.go
@@ -1,4 +1,4 @@
-// Good examples for the var018 test case.
+// Package var018 provides good test cases.
 package var018
 
 // Constants to avoid magic numbers


### PR DESCRIPTION
## Summary
Update all testdata package comments to follow Go convention:
`// Package <name> ...` instead of `// Good/Bad examples for ...`

87 files updated across all testdata directories.

## Test plan
- [x] `make lint` passes
- [x] `make validate` passes (98/98 checks OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)