### PR TITLE
fix(config): KTN-TEST rules ignore global exclusions

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -15,9 +15,10 @@ Rapport de couverture généré automatiquement.
 
 | Icon | Package | Coverage |
 |:----:|---------|----------|
-| 🟢 | **TOTAL (Global)** | **95.9%** |
+| 🟢 | **TOTAL (Global)** | **95.7%** |
 | 🔵 | `github.com/kodflow/ktn-linter/cmd/ktn-linter` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 95.4% |
+| 🟡 | `github.com/kodflow/ktn-linter/isolation` | 90.6% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` | 96.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.6% |
@@ -36,7 +37,7 @@ Rapport de couverture généré automatiquement.
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/formatter` | 99.5% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/messages` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/orchestrator` | 97.2% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/prompt` | 95.2% |
+| 🟡 | `github.com/kodflow/ktn-linter/pkg/prompt` | 90.8% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/rules` | 96.0% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/severity` | 100.0% |
 
@@ -53,6 +54,13 @@ Rapport de couverture généré automatiquement.
 | 🟡 `prompt.go:runPrompt` | 81.2% |
 | 🟡 `rules.go:runRules` | 83.3% |
 | 🟡 `rules.go:getRulesWithFilters` | 83.3% |
+
+### 🟡 `github.com/kodflow/ktn-linter/isolation` - 90.6%
+
+| Fichier:Fonction | Couverture |
+|------------------|------------|
+| 🟡 `linux.go:Create` | 88.9% |
+| 🟡 `linux.go:enableControllers` | 83.3% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` - 96.1%
 
@@ -238,11 +246,12 @@ Rapport de couverture généré automatiquement.
 | 🟢 `runner.go:Run` | 94.1% |
 | 🟡 `runner.go:analyzePackageParallel` | 90.9% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/prompt` - 95.2%
+### 🟡 `github.com/kodflow/ktn-linter/pkg/prompt` - 90.8%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
-| 🔴 `generator.go:collectViolations` | 50.0% |
+| 🔴 `generator.go:collectViolations` | 18.8% |
+| 🟡 `phases.go:ClassifyRule` | 88.9% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/rules` - 96.0%
 
@@ -253,4 +262,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-18 22:33:05*
+*Généré le: 2025-12-19 16:02:49*

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -181,6 +181,7 @@ func (c *Config) GetThreshold(ruleCode string, defaultValue int) int {
 }
 
 // IsFileExcluded checks if a file should be excluded for a specific rule.
+// KTN-TEST rules ignore ALL global exclusions (they only respect rule-specific exclusions).
 //
 // Params:
 //   - ruleCode: the rule code to check
@@ -195,9 +196,8 @@ func (c *Config) IsFileExcluded(ruleCode, filename string) bool {
 		return false
 	}
 
-	// Check global exclusions first
-	if c.matchesAnyPattern(filename, c.Exclude) {
-		// Return excluded by global pattern
+	// Check global exclusions (KTN-TEST rules ignore them)
+	if !strings.HasPrefix(ruleCode, "KTN-TEST-") && c.matchesAnyPattern(filename, c.Exclude) {
 		return true
 	}
 

--- a/pkg/config/config_external_test.go
+++ b/pkg/config/config_external_test.go
@@ -226,6 +226,54 @@ func TestConfig_IsFileExcluded(t *testing.T) {
 			filename: "pkg/analyzer/ktn/ktnfunc/testdata/good.go",
 			want:     true,
 		},
+		{
+			name: "KTN-TEST rules ignore global test exclusion",
+			cfg: &config.Config{
+				Exclude: []string{"*_test.go"},
+			},
+			ruleCode: "KTN-TEST-001",
+			filename: "foo_test.go",
+			want:     false,
+		},
+		{
+			name: "KTN-TEST rules ignore global test exclusion with path",
+			cfg: &config.Config{
+				Exclude: []string{"**/*_test.go"},
+			},
+			ruleCode: "KTN-TEST-005",
+			filename: "pkg/service/handler_test.go",
+			want:     false,
+		},
+		{
+			name: "KTN-TEST rules still respect rule-specific exclusions",
+			cfg: &config.Config{
+				Exclude: []string{"*_test.go"},
+				Rules: map[string]*config.RuleConfig{
+					"KTN-TEST-001": {Exclude: []string{"vendor/**"}},
+				},
+			},
+			ruleCode: "KTN-TEST-001",
+			filename: "vendor/lib_test.go",
+			want:     true,
+		},
+		{
+			name: "non-KTN-TEST rules still excluded by global pattern",
+			cfg: &config.Config{
+				Exclude: []string{"*_test.go"},
+			},
+			ruleCode: "KTN-FUNC-001",
+			filename: "foo_test.go",
+			want:     true,
+		},
+		{
+			name: "KTN-TEST rules ignore global exclusion for non-test files too",
+			cfg: &config.Config{
+				Exclude: []string{"vendor/**"},
+			},
+			ruleCode: "KTN-TEST-001",
+			filename: "vendor/lib.go",
+			want:     false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- KTN-TEST-* rules now bypass global file exclusions
- Ensures test linting rules always analyze test files
- Rule-specific exclusions are still respected

## Changes

- `pkg/config/config.go`: Modified `IsFileExcluded` to skip global exclusions for KTN-TEST rules
- `pkg/config/config_external_test.go`: Added 5 test cases for the new behavior

## Test plan

- `make test` passes with 95.7% coverage
- All new test cases verify the exclusion bypass logic