### PR TITLE
fix(orchestrator): resolve inspect.Analyzer cache issue for test rules

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -15,13 +15,12 @@ Rapport de couverture généré automatiquement.
 
 | Icon | Package | Coverage |
 |:----:|---------|----------|
-| 🟢 | **TOTAL (Global)** | **95.7%** |
+| 🟢 | **TOTAL (Global)** | **95.9%** |
 | 🔵 | `github.com/kodflow/ktn-linter/cmd/ktn-linter` | 100.0% |
-| 🟢 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 95.4% |
-| 🟡 | `github.com/kodflow/ktn-linter/isolation` | 90.6% |
+| 🟢 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 94.2% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` | 96.1% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.6% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnconst` | 98.5% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnfunc` | 96.4% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktninterface` | 100.0% |
@@ -36,8 +35,8 @@ Rapport de couverture généré automatiquement.
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/config` | 98.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/formatter` | 99.5% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/messages` | 100.0% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/orchestrator` | 97.2% |
-| 🟡 | `github.com/kodflow/ktn-linter/pkg/prompt` | 90.8% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/orchestrator` | 96.7% |
+| 🟢 | `github.com/kodflow/ktn-linter/pkg/prompt` | 98.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/rules` | 96.0% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/severity` | 100.0% |
 
@@ -45,22 +44,16 @@ Rapport de couverture généré automatiquement.
 
 ## Détail des packages incomplets
 
-### 🟢 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 95.4%
+### 🟢 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 94.2%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
+| 🟢 `lint.go:runLint` | 91.7% |
 | 🟡 `lint.go:loadConfiguration` | 90.0% |
 | 🟡 `lint.go:formatAndDisplay` | 88.9% |
-| 🟡 `prompt.go:runPrompt` | 81.2% |
+| 🔴 `prompt.go:runPrompt` | 75.0% |
 | 🟡 `rules.go:runRules` | 83.3% |
 | 🟡 `rules.go:getRulesWithFilters` | 83.3% |
-
-### 🟡 `github.com/kodflow/ktn-linter/isolation` - 90.6%
-
-| Fichier:Fonction | Couverture |
-|------------------|------------|
-| 🟡 `linux.go:Create` | 88.9% |
-| 🟡 `linux.go:enableControllers` | 83.3% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` - 96.1%
 
@@ -74,7 +67,7 @@ Rapport de couverture généré automatiquement.
 | 🟡 `001.go:getMethodSignature` | 87.5% |
 | 🟡 `001.go:getBaseIdent` | 85.7% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` - 98.6%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` - 98.1%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
@@ -82,6 +75,8 @@ Rapport de couverture généré automatiquement.
 | 🟢 `001.go:isDocComment` | 91.7% |
 | 🟢 `002.go:runComment002` | 93.3% |
 | 🟢 `005.go:runComment005` | 92.3% |
+| 🟢 `007.go:hasCommentBefore` | 92.9% |
+| 🟢 `007.go:hasInlineComment` | 93.3% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnconst` - 98.5%
 
@@ -237,20 +232,21 @@ Rapport de couverture généré automatiquement.
 |------------------|------------|
 | 🟡 `json.go:severityToLevel` | 80.0% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/orchestrator` - 97.2%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/orchestrator` - 96.7%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
 | 🟡 `loader.go:Load` | 85.7% |
 | 🟡 `orchestrator.go:Run` | 90.0% |
 | 🟢 `runner.go:Run` | 94.1% |
-| 🟡 `runner.go:analyzePackageParallel` | 90.9% |
+| 🟢 `runner.go:analyzePackageParallel` | 91.7% |
+| 🟡 `runner.go:runAnalyzerGroup` | 83.3% |
 
-### 🟡 `github.com/kodflow/ktn-linter/pkg/prompt` - 90.8%
+### 🟢 `github.com/kodflow/ktn-linter/pkg/prompt` - 98.0%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
-| 🔴 `generator.go:collectViolations` | 18.8% |
+| 🟡 `generator.go:collectViolations` | 87.5% |
 | 🟡 `phases.go:ClassifyRule` | 88.9% |
 
 ### 🟢 `github.com/kodflow/ktn-linter/pkg/rules` - 96.0%
@@ -262,4 +258,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-19 16:02:49*
+*Généré le: 2025-12-19 21:10:21*

--- a/cmd/ktn-linter/cmd/prompt_internal_test.go
+++ b/cmd/ktn-linter/cmd/prompt_internal_test.go
@@ -24,10 +24,10 @@ func Test_runPrompt(t *testing.T) {
 		checkStderr string
 	}{
 		{
-			name:       "valid formatter package",
+			name:       "valid formatter package with test issues",
 			packages:   []string{"github.com/kodflow/ktn-linter/pkg/formatter"},
 			expectExit: true,
-			exitCode:   0,
+			exitCode:   1, // Exit 1 because KTN-TEST-005/009 now correctly detect test issues
 		},
 		{
 			name:        "testdata with potential issues",

--- a/pkg/analyzer/ktn/ktncomment/007.go
+++ b/pkg/analyzer/ktn/ktncomment/007.go
@@ -304,6 +304,12 @@ func hasCommentBefore(pass *analysis.Pass, pos token.Pos) bool {
 		}
 	}
 
+	// Check if file was found
+	if file == nil {
+		// Retour si fichier non trouvé
+		return false
+	}
+
 	// Check all comments in the file
 	for _, commentGroup := range file.Comments {
 		commentPos := pass.Fset.Position(commentGroup.End())
@@ -337,6 +343,12 @@ func hasInlineComment(pass *analysis.Pass, pos token.Pos) bool {
 			file = f
 			break
 		}
+	}
+
+	// Check if file was found
+	if file == nil {
+		// Retour si fichier non trouvé
+		return false
 	}
 
 	// Check all comments in the file

--- a/pkg/analyzer/modernize/registry.go
+++ b/pkg/analyzer/modernize/registry.go
@@ -11,9 +11,11 @@ import (
 // Returns:
 //   - []*analysis.Analyzer: liste des analyseurs modernize
 func Analyzers() []*analysis.Analyzer {
-	// Liste des analyseurs à désactiver (bugs connus ou instables)
+	// Liste des analyseurs à désactiver (bugs connus ou instables avec Go 1.25.5)
 	disabled := map[string]bool{
-		"newexpr": true, // Désactivé: panic dans certains cas (nil pointer dereference)
+		"newexpr":        true, // Désactivé: panic dans certains cas (nil pointer dereference)
+		"omitzero":       true, // Désactivé: panic avec Go 1.25.5 (nil pointer dans checkOmitEmptyField)
+		"slicescontains": true, // Désactivé: panic avec Go 1.25.5 (nil pointer dans CoreType)
 	}
 
 	// Filtrer les analyseurs désactivés


### PR DESCRIPTION
## Summary

- Fix KTN-TEST-005 not detecting non-table-driven tests when running all rules together
- Root cause: inspect.Analyzer results cached per package but reused across analyzers with different file sets
- Test analyzers need all files, non-test analyzers need filtered files (without *_test.go)

## Changes

| File | Change |
|------|--------|
| `pkg/orchestrator/runner.go` | Separate analyzers into test/non-test groups, clear cache between groups |
| `pkg/analyzer/ktn/ktncomment/007.go` | Fix nil pointer in hasCommentBefore/hasInlineComment |
| `pkg/analyzer/modernize/registry.go` | Disable unstable analyzers (omitzero, slicescontains) |
| `cmd/ktn-linter/cmd/prompt_internal_test.go` | Update test expectation |

## Test plan

- [x] `make test` passes (95.9% coverage)
- [x] Tested on supervizio/daemon PR#5: 86 KTN-TEST-005 issues correctly detected
- [x] All 426 issues detected across 7 different rules