### PR TITLE
feat(cli): add --version flag to display version

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -17,7 +17,7 @@ Rapport de couverture généré automatiquement.
 |:----:|---------|----------|
 | 🟢 | **TOTAL (Global)** | **94.6%** |
 | 🔵 | `github.com/kodflow/ktn-linter/cmd/ktn-linter` | 100.0% |
-| 🟡 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 88.0% |
+| 🟡 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 88.1% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` | 96.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.1% |
@@ -45,7 +45,7 @@ Rapport de couverture généré automatiquement.
 
 ## Détail des packages incomplets
 
-### 🟡 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 88.0%
+### 🟡 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 88.1%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
@@ -272,4 +272,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-19 22:49:11*
+*Généré le: 2025-12-20 09:47:27*

--- a/cmd/ktn-linter/cmd/root.go
+++ b/cmd/ktn-linter/cmd/root.go
@@ -55,6 +55,7 @@ Examples:
 // Returns: aucun
 func SetVersion(v string) {
 	version = v
+	rootCmd.Version = v
 	rootCmd.Long = `KTN-Linter ` + v + ` - Linter for Go code following KTN (Kodflow Typing Notation) conventions.
 
 Examples:


### PR DESCRIPTION
## Summary

- Add `--version` flag to display the current version of ktn-linter
- Uses Cobra's built-in version flag functionality via `rootCmd.Version`

## Changes

- `cmd/ktn-linter/cmd/root.go`: Set `rootCmd.Version` in `SetVersion()` function

## Test plan

```bash
./builds/ktn-linter --version
# Expected output: ktn-linter version <version>
```