### PR TITLE
fix(orchestrator): prevent cache corruption between packages

### DIFF
--- a/pkg/orchestrator/runner.go
+++ b/pkg/orchestrator/runner.go
@@ -108,11 +108,12 @@ func (r *AnalysisRunner) worker(
 	wg waitGroup,
 ) {
 	defer wg.Done()
-	// Each worker has its own results map
-	results := make(map[*analysis.Analyzer]any, len(analyzers))
 
 	// Process packages from channel
 	for pkg := range pkgChan {
+		// Create fresh results map for each package to avoid cache corruption
+		// between packages (inspect.Analyzer caches AST data that is package-specific)
+		results := make(map[*analysis.Analyzer]any, len(analyzers))
 		r.analyzePackageParallel(pkg, analyzers, results, diagChan)
 	}
 }


### PR DESCRIPTION
## Bug

KTN-COMMENT-007 reports 336 false positives when running `ktn-linter lint ./...` with all rules, but passes when:
- Running with `--only-rule=KTN-COMMENT-007`
- Running with `--category=comment`
- Running each package individually

## Root Cause

The `results` map in `worker()` was created once per worker and reused across multiple packages. This caused `inspect.Analyzer` cache corruption:

```
1. Worker processes Package A (with tests)
2. results[inspect.Analyzer] = inspector for A's files
3. Clear results between test/non-test groups (within same package)
4. Worker processes Package B
5. results[inspect.Analyzer] still contains stale data from A!
6. runRequired() sees cache hit → skips running inspect.Analyzer
7. pass.Files = B's files, but ResultOf[inspect.Analyzer] = A's inspector
8. hasCommentBefore() tries to find B's filename in pass.Files
9. Inspector returns AST nodes from A, position resolves to A's filename
10. Filename from A not found in pass.Files → file == nil → return false
11. False positive: "bloc 'if' sans commentaire"
```

## Fix

Create a fresh `results` map for each package instead of reusing across packages:

```go
// Before (buggy)
func (r *AnalysisRunner) worker(...) {
    results := make(map[*analysis.Analyzer]any, len(analyzers)) // Once per worker
    for pkg := range pkgChan {
        r.analyzePackageParallel(pkg, analyzers, results, diagChan)
    }
}

// After (fixed)
func (r *AnalysisRunner) worker(...) {
    for pkg := range pkgChan {
        results := make(map[*analysis.Analyzer]any, len(analyzers)) // Fresh per package
        r.analyzePackageParallel(pkg, analyzers, results, diagChan)
    }
}
```

## Test Plan

- [ ] `ktn-linter lint ./...` should no longer report false positives for KTN-COMMENT-007
- [ ] All existing tests should pass
- [ ] Performance should not be significantly impacted (results map creation is O(1))

🤖 Generated with [Claude Code](https://claude.com/claude-code)