### PR TITLE
feat(cli): add multi-module discovery for lint command

### DIFF
--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -15,9 +15,9 @@ Rapport de couverture généré automatiquement.
 
 | Icon | Package | Coverage |
 |:----:|---------|----------|
-| 🟢 | **TOTAL (Global)** | **94.6%** |
+| 🟢 | **TOTAL (Global)** | **93.0%** |
 | 🔵 | `github.com/kodflow/ktn-linter/cmd/ktn-linter` | 100.0% |
-| 🟡 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 88.1% |
+| 🟡 | `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` | 84.2% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn` | 100.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktnapi` | 96.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/analyzer/ktn/ktncomment` | 98.1% |
@@ -35,7 +35,7 @@ Rapport de couverture généré automatiquement.
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/config` | 98.1% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/formatter` | 99.5% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/messages` | 100.0% |
-| 🟢 | `github.com/kodflow/ktn-linter/pkg/orchestrator` | 96.7% |
+| 🔴 | `github.com/kodflow/ktn-linter/pkg/orchestrator` | 64.2% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/prompt` | 98.0% |
 | 🟢 | `github.com/kodflow/ktn-linter/pkg/rules` | 96.0% |
 | 🔵 | `github.com/kodflow/ktn-linter/pkg/severity` | 100.0% |
@@ -45,12 +45,14 @@ Rapport de couverture généré automatiquement.
 
 ## Détail des packages incomplets
 
-### 🟡 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 88.1%
+### 🟡 `github.com/kodflow/ktn-linter/cmd/ktn-linter/cmd` - 84.2%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
 | 🟢 `lint.go:runLint` | 91.7% |
 | 🟡 `lint.go:loadConfiguration` | 90.0% |
+| 🟡 `lint.go:needsModuleDiscovery` | 88.9% |
+| 🔴 `lint.go:runSingleModulePipeline` | 23.1% |
 | 🟡 `lint.go:formatAndDisplay` | 88.9% |
 | 🔴 `prompt.go:runPrompt` | 75.0% |
 | 🟡 `rules.go:runRules` | 83.3% |
@@ -236,12 +238,21 @@ Rapport de couverture généré automatiquement.
 |------------------|------------|
 | 🟡 `json.go:severityToLevel` | 80.0% |
 
-### 🟢 `github.com/kodflow/ktn-linter/pkg/orchestrator` - 96.7%
+### 🔴 `github.com/kodflow/ktn-linter/pkg/orchestrator` - 64.2%
 
 | Fichier:Fonction | Couverture |
 |------------------|------------|
-| 🟡 `loader.go:Load` | 85.7% |
+| ⚫ `discovery.go:FindModules` | 0.0% |
+| ⚫ `discovery.go:findInPath` | 0.0% |
+| ⚫ `discovery.go:findModuleForFile` | 0.0% |
+| ⚫ `discovery.go:searchDirectory` | 0.0% |
+| ⚫ `discovery.go:ResolvePatterns` | 0.0% |
+| 🟡 `loader.go:LoadFromDir` | 85.7% |
 | 🟡 `orchestrator.go:Run` | 90.0% |
+| ⚫ `orchestrator.go:DiscoverModules` | 0.0% |
+| ⚫ `orchestrator.go:LoadPackagesFromDir` | 0.0% |
+| ⚫ `orchestrator.go:RunMultiModule` | 0.0% |
+| ⚫ `orchestrator.go:runSingleModule` | 0.0% |
 | 🟢 `runner.go:Run` | 94.1% |
 | 🟢 `runner.go:analyzePackageParallel` | 91.7% |
 | 🟡 `runner.go:runAnalyzerGroup` | 83.3% |
@@ -272,4 +283,4 @@ Rapport de couverture généré automatiquement.
 
 ---
 
-*Généré le: 2025-12-20 09:47:27*
+*Généré le: 2025-12-22 17:48:38*

--- a/pkg/orchestrator/discovery.go
+++ b/pkg/orchestrator/discovery.go
@@ -1,0 +1,190 @@
+// Package orchestrator coordinates the linting pipeline.
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ModuleDiscovery handles finding Go modules recursively.
+// Searches directories for go.mod files and returns module root paths.
+type ModuleDiscovery struct{}
+
+// NewModuleDiscovery creates a new ModuleDiscovery.
+//
+// Returns:
+//   - *ModuleDiscovery: new discovery instance
+func NewModuleDiscovery() *ModuleDiscovery {
+	// Return new instance
+	return &ModuleDiscovery{}
+}
+
+// FindModules finds all go.mod files in paths.
+//
+// Params:
+//   - paths: paths to search (files or directories)
+//
+// Returns:
+//   - []string: module root directories
+//   - error: search error if any
+func (d *ModuleDiscovery) FindModules(paths []string) ([]string, error) {
+	modules := make(map[string]struct{}, len(paths))
+
+	// Process each path
+	for _, p := range paths {
+		// Find modules in path
+		found, err := d.findInPath(p)
+		// Check for error
+		if err != nil {
+			// Return error with empty slice
+			return []string{}, err
+		}
+		// Add found modules
+		for _, m := range found {
+			modules[m] = struct{}{}
+		}
+	}
+
+	// Convert to slice
+	result := make([]string, 0, len(modules))
+	// Add all modules
+	for m := range modules {
+		result = append(result, m)
+	}
+
+	// Return found modules
+	return result, nil
+}
+
+// findInPath finds go.mod files in a single path.
+//
+// Params:
+//   - path: path to search
+//
+// Returns:
+//   - []string: module roots found
+//   - error: search error if any
+func (d *ModuleDiscovery) findInPath(path string) ([]string, error) {
+	// Get absolute path
+	absPath, err := filepath.Abs(path)
+	// Check for error
+	if err != nil {
+		// Return error with empty slice
+		return []string{}, err
+	}
+
+	// Check if path exists
+	info, err := os.Stat(absPath)
+	// Check for error
+	if err != nil {
+		// Return empty if not exists
+		return []string{}, nil
+	}
+
+	// Check if file
+	if !info.IsDir() {
+		// Find module for file
+		return d.findModuleForFile(absPath)
+	}
+
+	// Search directory recursively
+	return d.searchDirectory(absPath)
+}
+
+// findModuleForFile finds the module containing a file.
+//
+// Params:
+//   - filePath: path to file
+//
+// Returns:
+//   - []string: module root if found
+//   - error: search error if any
+func (d *ModuleDiscovery) findModuleForFile(filePath string) ([]string, error) {
+	dir := filepath.Dir(filePath)
+	// Walk up directory tree
+	for dir != "/" && dir != "." {
+		goMod := filepath.Join(dir, "go.mod")
+		// Check if go.mod exists
+		if _, err := os.Stat(goMod); err == nil {
+			// Return module root
+			return []string{dir}, nil
+		}
+		// Move up
+		dir = filepath.Dir(dir)
+	}
+	// No module found - return empty slice
+	return []string{}, nil
+}
+
+// searchDirectory searches for go.mod files recursively.
+//
+// Params:
+//   - dir: directory to search
+//
+// Returns:
+//   - []string: module roots found
+//   - error: search error if any
+func (d *ModuleDiscovery) searchDirectory(dir string) ([]string, error) {
+	var modules []string
+
+	// Walk directory tree
+	err := filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
+		// Skip inaccessible directories
+		if walkErr != nil {
+			// Continue walking
+			return nil
+		}
+
+		// Skip hidden directories
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), ".") {
+			// Skip hidden directory
+			return filepath.SkipDir
+		}
+
+		// Skip vendor directories
+		if entry.IsDir() && entry.Name() == "vendor" {
+			// Skip vendor directory
+			return filepath.SkipDir
+		}
+
+		// Check for go.mod file
+		if entry.Name() == "go.mod" {
+			modules = append(modules, filepath.Dir(path))
+		}
+
+		// Continue walking
+		return nil
+	})
+
+	// Check for walk error
+	if err != nil {
+		// Return error with empty slice
+		return []string{}, err
+	}
+
+	// Return found modules
+	return modules, nil
+}
+
+// ResolvePatterns resolves patterns for a module.
+//
+// Params:
+//   - _moduleRoot: root directory of module (reserved for future use)
+//   - originalPatterns: original patterns from CLI
+//
+// Returns:
+//   - []string: resolved patterns for this module
+func (d *ModuleDiscovery) ResolvePatterns(_moduleRoot string, originalPatterns []string) []string {
+	// Check for ./... pattern
+	for _, p := range originalPatterns {
+		// Check if recursive pattern
+		if p == "./..." || strings.HasSuffix(p, "/...") {
+			// Return recursive pattern for module
+			return []string{"./..."}
+		}
+	}
+
+	// Default to recursive
+	return []string{"./..."}
+}

--- a/pkg/orchestrator/discovery_external_test.go
+++ b/pkg/orchestrator/discovery_external_test.go
@@ -1,0 +1,226 @@
+package orchestrator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/kodflow/ktn-linter/pkg/orchestrator"
+)
+
+// TestNewModuleDiscovery tests the constructor.
+func TestNewModuleDiscovery(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	// Check not nil
+	if d == nil {
+		t.Error("expected non-nil ModuleDiscovery")
+	}
+}
+
+// TestFindModulesEmpty tests finding modules with empty input.
+func TestFindModulesEmpty(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	modules, err := d.FindModules([]string{})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check empty result
+	if len(modules) != 0 {
+		t.Errorf("expected 0 modules, got %d", len(modules))
+	}
+}
+
+// TestFindModulesCurrentDir tests finding module in current directory.
+func TestFindModulesCurrentDir(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	// Use workspace root which has go.mod
+	modules, err := d.FindModules([]string{"/workspace"})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check found module
+	if len(modules) != 1 {
+		t.Errorf("expected 1 module, got %d", len(modules))
+	}
+}
+
+// TestFindModulesNonExistent tests finding modules in non-existent path.
+func TestFindModulesNonExistent(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	modules, err := d.FindModules([]string{"/nonexistent/path"})
+	// Check no error (returns empty)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check empty result
+	if len(modules) != 0 {
+		t.Errorf("expected 0 modules, got %d", len(modules))
+	}
+}
+
+// TestFindModulesFile tests finding module for a file.
+func TestFindModulesFile(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	// Use a file in the workspace
+	modules, err := d.FindModules([]string{"/workspace/go.mod"})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check found module
+	if len(modules) != 1 {
+		t.Errorf("expected 1 module, got %d", len(modules))
+	}
+}
+
+// TestFindModulesSkipsVendor tests that vendor directories are skipped.
+func TestFindModulesSkipsVendor(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+	// Create main go.mod
+	mainMod := filepath.Join(tmpDir, "go.mod")
+	err := os.WriteFile(mainMod, []byte("module test\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create vendor directory with go.mod
+	vendorDir := filepath.Join(tmpDir, "vendor", "dep")
+	err = os.MkdirAll(vendorDir, 0o755)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	vendorMod := filepath.Join(vendorDir, "go.mod")
+	err = os.WriteFile(vendorMod, []byte("module dep\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := orchestrator.NewModuleDiscovery()
+	modules, err := d.FindModules([]string{tmpDir})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check only main module found (vendor skipped)
+	if len(modules) != 1 {
+		t.Errorf("expected 1 module (vendor skipped), got %d", len(modules))
+	}
+}
+
+// TestFindModulesSkipsHidden tests that hidden directories are skipped.
+func TestFindModulesSkipsHidden(t *testing.T) {
+	// Create temp directory structure
+	tmpDir := t.TempDir()
+	// Create main go.mod
+	mainMod := filepath.Join(tmpDir, "go.mod")
+	err := os.WriteFile(mainMod, []byte("module test\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create hidden directory with go.mod
+	hiddenDir := filepath.Join(tmpDir, ".hidden")
+	err = os.MkdirAll(hiddenDir, 0o755)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	hiddenMod := filepath.Join(hiddenDir, "go.mod")
+	err = os.WriteFile(hiddenMod, []byte("module hidden\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := orchestrator.NewModuleDiscovery()
+	modules, err := d.FindModules([]string{tmpDir})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check only main module found (hidden skipped)
+	if len(modules) != 1 {
+		t.Errorf("expected 1 module (hidden skipped), got %d", len(modules))
+	}
+}
+
+// TestResolvePatternsRecursive tests pattern resolution for recursive.
+func TestResolvePatternsRecursive(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	patterns := d.ResolvePatterns("/workspace", []string{"./..."})
+	// Check result
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Errorf("expected [./...], got %v", patterns)
+	}
+}
+
+// TestResolvePatternsDefault tests pattern resolution for default.
+func TestResolvePatternsDefault(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	patterns := d.ResolvePatterns("/workspace", []string{"/some/path"})
+	// Check result (default to recursive)
+	if len(patterns) != 1 || patterns[0] != "./..." {
+		t.Errorf("expected [./...], got %v", patterns)
+	}
+}
+
+// TestFindModulesMultiple tests finding multiple modules.
+func TestFindModulesMultiple(t *testing.T) {
+	// Create temp directory structure with 2 modules
+	tmpDir := t.TempDir()
+	// Create first module
+	mod1 := filepath.Join(tmpDir, "mod1")
+	err := os.MkdirAll(mod1, 0o755)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(mod1, "go.mod"), []byte("module mod1\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create second module
+	mod2 := filepath.Join(tmpDir, "mod2")
+	err = os.MkdirAll(mod2, 0o755)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(mod2, "go.mod"), []byte("module mod2\n"), 0o644)
+	// Check error
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d := orchestrator.NewModuleDiscovery()
+	modules, err := d.FindModules([]string{tmpDir})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check found both modules
+	if len(modules) != 2 {
+		t.Errorf("expected 2 modules, got %d", len(modules))
+	}
+}
+
+// TestFindModulesDeduplicate tests that duplicate modules are handled.
+func TestFindModulesDeduplicate(t *testing.T) {
+	d := orchestrator.NewModuleDiscovery()
+	// Pass same path twice
+	modules, err := d.FindModules([]string{"/workspace", "/workspace"})
+	// Check no error
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	// Check deduplicated
+	if len(modules) != 1 {
+		t.Errorf("expected 1 module (deduplicated), got %d", len(modules))
+	}
+}

--- a/pkg/orchestrator/loader.go
+++ b/pkg/orchestrator/loader.go
@@ -36,10 +36,25 @@ func NewPackageLoader(stderr io.Writer) *PackageLoader {
 //   - []*packages.Package: loaded packages
 //   - error: loading error if any
 func (l *PackageLoader) Load(patterns []string) ([]*packages.Package, error) {
+	// Load from current directory
+	return l.LoadFromDir("", patterns)
+}
+
+// LoadFromDir loads Go packages from a specific directory.
+//
+// Params:
+//   - dir: directory containing go.mod (empty for current)
+//   - patterns: package patterns to load
+//
+// Returns:
+//   - []*packages.Package: loaded packages
+//   - error: loading error if any
+func (l *PackageLoader) LoadFromDir(dir string, patterns []string) ([]*packages.Package, error) {
 	cfg := &packages.Config{
 		Mode:       packages.NeedName | packages.NeedFiles | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo,
 		Tests:      true,
 		BuildFlags: []string{"-buildvcs=false"},
+		Dir:        dir,
 	}
 
 	pkgs, err := packages.Load(cfg, patterns...)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -2,6 +2,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"io"
 
 	"golang.org/x/tools/go/analysis"
@@ -11,12 +12,13 @@ import (
 // Orchestrator coordinates the linting process.
 // It manages package loading, analyzer selection, execution, and diagnostics processing.
 type Orchestrator struct {
-	loader     *PackageLoader
-	selector   *AnalyzerSelector
-	runner     *AnalysisRunner
-	processor  *DiagnosticsProcessor
-	stderr     io.Writer
-	verbose    bool
+	loader    *PackageLoader
+	selector  *AnalyzerSelector
+	runner    *AnalysisRunner
+	processor *DiagnosticsProcessor
+	discovery *ModuleDiscovery
+	stderr    io.Writer
+	verbose   bool
 }
 
 // NewOrchestrator creates a new Orchestrator.
@@ -34,6 +36,7 @@ func NewOrchestrator(stderr io.Writer, verbose bool) *Orchestrator {
 		selector:  NewAnalyzerSelector(stderr, verbose),
 		runner:    NewAnalysisRunner(stderr, verbose),
 		processor: NewDiagnosticsProcessor(),
+		discovery: NewModuleDiscovery(),
 		stderr:    stderr,
 		verbose:   verbose,
 	}
@@ -156,4 +159,127 @@ func GetFirstFset(diagnostics []DiagnosticResult) any {
 	}
 	// Return first fset
 	return diagnostics[0].Fset
+}
+
+// DiscoverModules finds all Go modules in paths.
+//
+// Params:
+//   - paths: paths to search
+//
+// Returns:
+//   - []string: module root directories
+//   - error: discovery error if any
+func (o *Orchestrator) DiscoverModules(paths []string) ([]string, error) {
+	// Delegate to discovery
+	return o.discovery.FindModules(paths)
+}
+
+// LoadPackagesFromDir loads packages from a specific directory.
+//
+// Params:
+//   - dir: module root directory
+//   - patterns: package patterns
+//
+// Returns:
+//   - []*packages.Package: loaded packages
+//   - error: loading error if any
+func (o *Orchestrator) LoadPackagesFromDir(dir string, patterns []string) ([]*packages.Package, error) {
+	// Delegate to loader
+	return o.loader.LoadFromDir(dir, patterns)
+}
+
+// RunMultiModule runs analysis across multiple modules.
+//
+// Params:
+//   - paths: paths to analyze (may contain multiple modules)
+//   - opts: linting options
+//
+// Returns:
+//   - []DiagnosticResult: aggregated diagnostics
+//   - error: pipeline error if any
+func (o *Orchestrator) RunMultiModule(paths []string, opts Options) ([]DiagnosticResult, error) {
+	// Discover modules
+	modules, err := o.DiscoverModules(paths)
+	// Check for error
+	if err != nil {
+		return nil, fmt.Errorf("discovering modules: %w", err)
+	}
+
+	// Check if no modules found
+	if len(modules) == 0 {
+		// Fall back to standard load from current directory
+		return o.runSingleModule("", paths, opts)
+	}
+
+	// Log if verbose
+	if o.verbose {
+		fmt.Fprintf(o.stderr, "Found %d Go module(s)\n", len(modules))
+	}
+
+	// Select analyzers once
+	analyzers, err := o.SelectAnalyzers(opts)
+	// Check for error
+	if err != nil {
+		return nil, err
+	}
+
+	// Aggregate results
+	var allDiags []DiagnosticResult
+
+	// Process each module
+	for _, moduleRoot := range modules {
+		// Log if verbose
+		if o.verbose {
+			fmt.Fprintf(o.stderr, "Analyzing module: %s\n", moduleRoot)
+		}
+
+		// Get patterns for this module
+		patterns := o.discovery.ResolvePatterns(moduleRoot, paths)
+
+		// Load packages from module directory
+		pkgs, err := o.LoadPackagesFromDir(moduleRoot, patterns)
+		// Check for error
+		if err != nil {
+			// Log warning and continue
+			if o.verbose {
+				fmt.Fprintf(o.stderr, "Warning: %v\n", err)
+			}
+			continue
+		}
+
+		// Run analyzers
+		diags := o.RunAnalyzers(pkgs, analyzers)
+		allDiags = append(allDiags, diags...)
+	}
+
+	return allDiags, nil
+}
+
+// runSingleModule runs analysis for a single module.
+//
+// Params:
+//   - dir: module directory (empty for current)
+//   - patterns: package patterns
+//   - opts: linting options
+//
+// Returns:
+//   - []DiagnosticResult: collected diagnostics
+//   - error: pipeline error if any
+func (o *Orchestrator) runSingleModule(dir string, patterns []string, opts Options) ([]DiagnosticResult, error) {
+	// Load packages
+	pkgs, err := o.LoadPackagesFromDir(dir, patterns)
+	// Check for error
+	if err != nil {
+		return nil, err
+	}
+
+	// Select analyzers
+	analyzers, err := o.SelectAnalyzers(opts)
+	// Check for error
+	if err != nil {
+		return nil, err
+	}
+
+	// Run analyzers
+	return o.RunAnalyzers(pkgs, analyzers), nil
 }


### PR DESCRIPTION
## Summary

- Add recursive go.mod discovery to enable linting from any directory
- When a directory path is provided, the linter searches for all Go modules and analyzes each independently
- Fixes the issue where `ktn-linter lint /path/to/folder` returned no results

## Changes

| File | Description |
|------|-------------|
| `pkg/orchestrator/discovery.go` | New module discovery logic |
| `pkg/orchestrator/discovery_external_test.go` | Tests for discovery |
| `pkg/orchestrator/loader.go` | Add `LoadFromDir` method |
| `pkg/orchestrator/orchestrator.go` | Add `RunMultiModule` pipeline |
| `cmd/ktn-linter/cmd/lint.go` | Auto-detect multi-module mode |

## Test plan

- [x] Unit tests for discovery module
- [x] Test from `/tmp`: `ktn-linter lint /workspace` now correctly finds issues
- [x] Existing tests pass (93% coverage)