### PR TITLE
test(ktnconst): improve testdata coverage for const rules

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
     // "./features/languages/cpp": {},
     // "./features/languages/dart-flutter": {},
     // "./features/languages/elixir": {},
-    // "./features/languages/go": {},
+    "./features/languages/go": {},
     // "./features/languages/java": {},
     // "./features/languages/php": {},
     // "./features/languages/python": {},

--- a/pkg/analyzer/ktn/ktnconst/001_external_test.go
+++ b/pkg/analyzer/ktn/ktnconst/001_external_test.go
@@ -20,20 +20,20 @@ func TestConst001(t *testing.T) {
 			name:           "constants without explicit type",
 			analyzer:       ktnconst.Analyzer001,
 			testdataDir:    "const001",
-			expectedErrors: 13,
+			expectedErrors: 16,
 		},
 		{
 			name:           "valid constants with explicit type",
 			analyzer:       ktnconst.Analyzer001,
 			testdataDir:    "const001",
-			expectedErrors: 13,
+			expectedErrors: 16,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// good.go: 0 errors, bad.go: 13 errors (constants without explicit type)
-			// - 10 in block + 1 iota + 2 multi-name
+			// good.go: 0 errors, bad.go: 16 errors (constants without explicit type)
+			// - 8 basic + 5 numeric + 1 rune + 1 iota + 2 multi-name - 1 inherited = 16
 			testhelper.TestGoodBad(t, tt.analyzer, tt.testdataDir, tt.expectedErrors)
 		})
 	}

--- a/pkg/analyzer/ktn/ktnconst/003_external_test.go
+++ b/pkg/analyzer/ktn/ktnconst/003_external_test.go
@@ -20,20 +20,20 @@ func TestConst003(t *testing.T) {
 			name:           "constants with underscores violating CamelCase",
 			analyzer:       ktnconst.Analyzer003,
 			testdataDir:    "const003",
-			expectedErrors: 15,
+			expectedErrors: 20,
 		},
 		{
 			name:           "valid CamelCase constants",
 			analyzer:       ktnconst.Analyzer003,
 			testdataDir:    "const003",
-			expectedErrors: 15,
+			expectedErrors: 20,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// good.go: 0 errors (CamelCase is valid)
-			// bad.go: 15 errors (constants with underscores violate CamelCase convention)
+			// bad.go: 20 errors (constants with underscores violate CamelCase convention)
 			testhelper.TestGoodBad(t, tt.analyzer, tt.testdataDir, tt.expectedErrors)
 		})
 	}

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const001/bad.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const001/bad.go
@@ -4,43 +4,57 @@ package const001
 // Bad: All constants WITHOUT explicit types (violates KTN-CONST-001)
 // Names use CamelCase to avoid CONST-003 errors
 const (
-	// BadMaxConnections defines max connections
+	// === Basic types without explicit type ===
+
+	// BadMaxConnections defines max connections (int)
 	BadMaxConnections = 100 // want "KTN-CONST-001"
-	// BadPortNumber defines server port
+	// BadPortNumber defines server port (int)
 	BadPortNumber = 8080 // want "KTN-CONST-001"
-	// BadTimeoutMs defines timeout in ms
+	// BadTimeoutMs defines timeout in ms (int)
 	BadTimeoutMs = 5000 // want "KTN-CONST-001"
 
-	// BadHttpOk represents HTTP 200 status
-	BadHttpOk = 200 // want "KTN-CONST-001"
-	// BadHttpNotFound represents 404
-	BadHttpNotFound = 404 // want "KTN-CONST-001"
-
-	// BadApiVersion defines API version
+	// BadApiVersion defines API version (string)
 	BadApiVersion = "v1.0" // want "KTN-CONST-001"
-	// BadDefaultLang defines default lang
+	// BadDefaultLang defines default lang (string)
 	BadDefaultLang = "en" // want "KTN-CONST-001"
 
-	// BadIsProduction indicates prod mode
+	// BadIsProduction indicates prod mode (bool)
 	BadIsProduction = true // want "KTN-CONST-001"
-	// BadEnableCache indicates cache on
+	// BadEnableCache indicates cache on (bool)
 	BadEnableCache = false // want "KTN-CONST-001"
 
-	// BadRatio defines calculation ratio
+	// BadRatio defines calculation ratio (float64)
 	BadRatio = 1.5 // want "KTN-CONST-001"
+
+	// === Additional numeric types without explicit type (T1.3) ===
+
+	// BadByteVal represents a byte value
+	BadByteVal = 0xFF // want "KTN-CONST-001"
+	// BadInt64Val represents a large int
+	BadInt64Val = 9223372036854775807 // want "KTN-CONST-001"
+	// BadUintVal represents an unsigned int
+	BadUintVal = 42 // want "KTN-CONST-001"
+	// BadFloat32Val represents a float
+	BadFloat32Val = 3.14 // want "KTN-CONST-001"
+
+	// === Rune type without explicit type ===
+
+	// BadNewlineChar represents a newline
+	BadNewlineChar = '\n' // want "KTN-CONST-001"
+
+	// === Iota without explicit type ===
 
 	// BadStateA without explicit type
 	BadStateA = iota // want "KTN-CONST-001"
-	// BadStateB inherits (no error)
+	// BadStateB inherits (no error - inherits from previous)
 	BadStateB
-	// BadStateC inherits (no error)
+	// BadStateC inherits (no error - inherits from previous)
 	BadStateC
 
-	// BadMultiA without explicit type
+	// === Multi-name without explicit type ===
+
+	// BadMultiA and BadMultiB without explicit type
 	// want "KTN-CONST-001"
 	// want "KTN-CONST-001"
 	BadMultiA, BadMultiB = 10, 20
 )
-
-// BadStatus is a type declared after const (for testing purposes only)
-type BadStatus int

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const001/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const001/good.go
@@ -1,8 +1,13 @@
 // Package const001 provides good test cases.
 package const001
 
+// CustomInt is a custom integer type for testing typed constants.
+type CustomInt int
+
 // Good: All constants in a single grouped block with explicit types
 const (
+	// === Basic types (int, string, bool, float64) ===
+
 	// MaxTimeout defines the maximum timeout in seconds
 	MaxTimeout int = 30
 	// RetryCount specifies the number of retry attempts
@@ -11,34 +16,72 @@ const (
 	DefaultRatio float64 = 1.5
 	// AppName is the application name
 	AppName string = "myapp"
-
-	// Iota with explicit type on first line (using int)
-	// StatusPending represents a pending status
-	StatusPending int = iota
-	// StatusRunning represents a running status (inherits type from previous)
-	StatusRunning
-	// StatusCompleted represents a completed status (inherits type from previous)
-	StatusCompleted
-
-	// Pi represents the mathematical constant pi
-	Pi float64 = 3.14159
-	// E represents Euler's number
-	E float64 = 2.71828
-
 	// FeatureEnabled indicates if the feature is enabled
 	FeatureEnabled bool = true
 	// DebugMode indicates if debug mode is active
 	DebugMode bool = false
 
-	// Exotic types
+	// === Iota with explicit type ===
+
+	// StatusPending represents a pending status
+	StatusPending int = iota
+	// StatusRunning represents a running status (inherits type)
+	StatusRunning
+	// StatusCompleted represents a completed status (inherits type)
+	StatusCompleted
+
+	// === Additional numeric types (T1.1) ===
+
+	// ByteValue represents a byte constant
+	ByteValue byte = 0xFF
+	// Int8Value represents an int8 constant
+	Int8Value int8 = -128
+	// Int16Value represents an int16 constant
+	Int16Value int16 = -32768
+	// Int32Value represents an int32 constant
+	Int32Value int32 = -2147483648
+	// Int64Value represents an int64 constant
+	Int64Value int64 = -9223372036854775808
+	// UintValue represents a uint constant
+	UintValue uint = 42
+	// Uint8Value represents a uint8 constant
+	Uint8Value uint8 = 255
+	// Uint16Value represents a uint16 constant
+	Uint16Value uint16 = 65535
+	// Uint32Value represents a uint32 constant
+	Uint32Value uint32 = 4294967295
+	// Uint64Value represents a uint64 constant
+	Uint64Value uint64 = 18446744073709551615
+	// Float32Value represents a float32 constant
+	Float32Value float32 = 3.14
+	// UintptrValue represents a uintptr constant
+	UintptrValue uintptr = 0x1234
+
+	// === Float and complex types ===
+
+	// Pi represents the mathematical constant pi
+	Pi float64 = 3.14159
+	// E represents Euler's number
+	E float64 = 2.71828
+	// Complex64Value represents a complex64 constant
+	Complex64Value complex64 = 1 + 2i
+	// ComplexValue represents a complex128 number
+	ComplexValue complex128 = 1 + 2i
+
+	// === Rune type ===
+
 	// NewlineChar represents a newline character
 	NewlineChar rune = '\n'
 	// TabChar represents a tab character
 	TabChar rune = '\t'
-	// ComplexValue represents a complex number
-	ComplexValue complex128 = 1 + 2i
 
-	// Multi-name with explicit type (all names share the type)
+	// === Custom type constant (T1.2) ===
+
+	// CustomValue is a constant with custom type
+	CustomValue CustomInt = 42
+
+	// === Multi-name with explicit type ===
+
 	// FirstVal and SecondVal are related values
 	FirstVal, SecondVal int = 1, 2
 )

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const002/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const002/good.go
@@ -2,7 +2,7 @@
 package const002
 
 // Good: All constants grouped in a single block at the very top
-// Order is correct: const → var → type
+// Order is correct: const → var → type → func
 const (
 	// ConfigValue1 is the first configuration value
 	ConfigValue1 string = "config1"
@@ -14,6 +14,16 @@ const (
 	MaxRetry int = 5
 	// TimeoutSec defines the timeout in seconds
 	TimeoutSec int = 30
+
+	// === Iota pattern with int type (T2.2) ===
+	// Demonstrates iota within the main const block
+
+	// StatusPending is the pending status
+	StatusPending int = iota
+	// StatusActive is the active status
+	StatusActive
+	// StatusDone is the done status
+	StatusDone
 )
 
 // Variables come after constants (correct order)
@@ -24,7 +34,9 @@ var (
 	GlobalVar2 string = "var2"
 )
 
-// Types come after variables (correct order)
+// === Type declarations come after variables (correct order) ===
+
+// goodType is a struct type
 type goodType struct {
 	// Field is a field
 	Field string
@@ -32,3 +44,20 @@ type goodType struct {
 
 // anotherType is another type declaration
 type anotherType int
+
+// Status is a custom type for status values
+type Status int
+
+// === Functions come after types (correct order - T2.1) ===
+
+// helperFunc is a helper function to validate const → var → type → func order
+func helperFunc() string {
+	// Use declarations to avoid unused errors
+	return ConfigValue1
+}
+
+// anotherFunc demonstrates multiple functions after types
+func anotherFunc() int {
+	// Return a constant value
+	return MaxRetry
+}

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const003/bad.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const003/bad.go
@@ -4,7 +4,8 @@ package const003
 // Bad: Invalid naming (violates KTN-CONST-003)
 // Contains underscores which is not Go CamelCase convention
 const (
-	// SCREAMING_SNAKE_CASE naming (INVALID - contains underscores)
+	// === SCREAMING_SNAKE_CASE naming (INVALID) ===
+
 	// MaxSizeSnake contains underscore
 	MAX_SIZE int = 100 // want "KTN-CONST-003"
 	// ApiKeySnake contains underscore
@@ -12,7 +13,8 @@ const (
 	// HttpTimeoutSnake contains underscore
 	HTTP_TIMEOUT int = 30 // want "KTN-CONST-003"
 
-	// snake_case (lowercase with underscores) - INVALID
+	// === snake_case (lowercase with underscores) - INVALID ===
+
 	// maxSizeSnakeLower contains underscore
 	max_size int = 100 // want "KTN-CONST-003"
 	// apiKeySnakeLower contains underscore
@@ -20,7 +22,8 @@ const (
 	// httpTimeoutSnakeLower contains underscore
 	http_timeout int = 30 // want "KTN-CONST-003"
 
-	// Mixed case with underscores - INVALID
+	// === Mixed case with underscores - INVALID ===
+
 	// MaxSizeMixed contains underscore
 	Max_Size int = 100 // want "KTN-CONST-003"
 	// ApiKeyMixed contains underscore
@@ -28,19 +31,31 @@ const (
 	// HttpTimeoutMixed contains underscore
 	Http_Timeout int = 30 // want "KTN-CONST-003"
 
-	// More SCREAMING_SNAKE examples
+	// === Complex underscored names ===
+
 	// DatabaseMaxConn contains underscore
 	DB_MAX_CONNECTIONS int = 100 // want "KTN-CONST-003"
 	// DefaultPortNumber contains underscore
 	DEFAULT_PORT int = 8080 // want "KTN-CONST-003"
 	// IsProductionMode contains underscore
 	IS_PRODUCTION bool = false // want "KTN-CONST-003"
-
-	// Complex underscored names
 	// ConnectionPoolSize contains underscore
 	MAX_CONNECTION_POOL_SIZE int = 50 // want "KTN-CONST-003"
 	// RequestTimeoutSec contains underscore
 	DEFAULT_REQUEST_TIMEOUT int = 60 // want "KTN-CONST-003"
 	// ApiKeyHeader contains underscore
 	API_KEY_HEADER_NAME string = "X-API" // want "KTN-CONST-003"
+
+	// === Edge cases with underscores (T3.1) ===
+
+	// Double underscore
+	double__underscore int = 1 // want "KTN-CONST-003"
+	// Trailing underscore
+	trailing_ int = 2 // want "KTN-CONST-003"
+	// Leading underscore (not blank identifier)
+	_leading int = 3 // want "KTN-CONST-003"
+	// Multiple underscores in sequence
+	a___b int = 4 // want "KTN-CONST-003"
+	// Underscore between numbers
+	value_1_2 int = 5 // want "KTN-CONST-003"
 )

--- a/pkg/analyzer/ktn/ktnconst/testdata/src/const003/good.go
+++ b/pkg/analyzer/ktn/ktnconst/testdata/src/const003/good.go
@@ -3,7 +3,8 @@ package const003
 
 // Good: All constants use CamelCase naming (Go standard)
 const (
-	// Single letter constants are valid
+	// === Single letter constants (valid) ===
+
 	// A represents the first value
 	A int = 1
 	// B represents the second value
@@ -11,7 +12,8 @@ const (
 	// C represents the third value
 	C int = 3
 
-	// PascalCase for exported constants
+	// === PascalCase for exported constants ===
+
 	// MaxSize defines the maximum size
 	MaxSize int = 100
 	// ApiKey is the authentication key
@@ -23,7 +25,8 @@ const (
 	// MinRetryCount defines minimum retries
 	MinRetryCount int = 3
 
-	// Acronyms in PascalCase
+	// === Acronyms in PascalCase ===
+
 	// APIEndpoint is the API endpoint
 	APIEndpoint string = "/api"
 	// HTTPStatus is the HTTP status code
@@ -31,7 +34,8 @@ const (
 	// URLPath is the URL path
 	URLPath string = "/path"
 
-	// camelCase for unexported constants
+	// === camelCase for unexported constants ===
+
 	// maxInternalSize is internal max size
 	maxInternalSize int = 50
 	// defaultTimeout is the default timeout
@@ -39,7 +43,8 @@ const (
 	// httpInternalPort is internal port
 	httpInternalPort int = 8080
 
-	// Constants with numbers
+	// === Constants with numbers ===
+
 	// Http2Protocol is HTTP/2 protocol
 	Http2Protocol string = "h2"
 	// Tls12Version is TLS 1.2 version
@@ -47,7 +52,8 @@ const (
 	// Version100 is version 1.0.0
 	Version100 string = "1.0.0"
 
-	// Complex names without underscores
+	// === Complex names without underscores ===
+
 	// MaxConnectionPoolSize defines pool size
 	MaxConnectionPoolSize int = 50
 	// DefaultRequestTimeoutSeconds timeout value
@@ -55,7 +61,8 @@ const (
 	// ApiKeyHeaderName header name for API key
 	ApiKeyHeaderName string = "X-API-Key"
 
-	// Status codes
+	// === Status codes ===
+
 	// StatusOK success status
 	StatusOK int = 200
 	// StatusCreated resource created
@@ -63,11 +70,30 @@ const (
 	// StatusAccepted request accepted
 	StatusAccepted int = 202
 
+	// === Special cases ===
+
 	// Blank identifier (valid - should be skipped)
 	_ int = 999
-
 	// TestValue used for testing
 	TestValue int = 123
+
+	// === Constant without explicit type (T3.2) ===
+	// This tests that CONST-003 works independently from CONST-001
+	// The naming is still valid CamelCase
+
+	// NoTypeValue is a constant without explicit type
+	NoTypeValue = 42
+	// NoTypeString is a string without explicit type
+	NoTypeString = "test"
+
+	// === Very long names (T3.3) ===
+
+	// VeryLongConstantNameWithManyWordsInCamelCaseFormat is a long name
+	VeryLongConstantNameWithManyWordsInCamelCaseFormat int = 1
+	// ThisIsAnExtremelyLongConstantNameThatShouldStillBeValidCamelCase long
+	ThisIsAnExtremelyLongConstantNameThatShouldStillBeValidCamelCase int = 2
+	// shortName is a short name for comparison
+	shortName int = 3
 )
 
 // Variable declaration to test that only const are checked


### PR DESCRIPTION
## Summary
- Improve test coverage for KTN-CONST-001, KTN-CONST-002, and KTN-CONST-003 rules
- Add missing numeric types, custom types, and edge cases to testdata
- Enable Go feature in devcontainer for development

## Changes
- `const001/good.go`: Added all numeric types (byte, int8-64, uint8-64, float32, complex64, uintptr) + CustomInt type
- `const001/bad.go`: Added 5 more constants without explicit type (16 total errors)
- `const002/good.go`: Added functions to validate const→var→type→func order + iota pattern
- `const003/bad.go`: Added underscore edge cases (double, trailing, leading, multiple)
- `const003/good.go`: Added constants without type + very long CamelCase names
- Updated test expectations to match new error counts

## Test plan
- [x] All ktnconst tests pass (30+ test cases)
- [x] All KTN analyzer tests pass
- [ ] CI validation